### PR TITLE
Fix README link to it-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Utility modules to make dealing with async iterators easier, some trivial, some 
 * [it-all](./packages/it-all) Collect the contents of an iterable into an array
 * [it-batch](./packages/it-batch) Batch up the contents of an iterable into arrays
 * [it-buffer-stream](./packages/it-buffer-stream) Creates an iterable of buffers
-* [it-first]('./packages/it-first) Return the first item in an iterable
+* [it-first](./packages/it-first) Return the first item in an iterable
 * [it-flat-batch](./packages/it-flat-batch) Take an iterable of variable length arrays and make them all the same length
 * [it-glob](./packages/it-glob) Glob matcher for file systems
 * [it-last](./packages/it-last) Return the last item in an iterable


### PR DESCRIPTION
The README's link to `it-first` had an extra character, which caused the link to break.