### PR TITLE
feat: add types

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,3 @@ Thumbs.db
 .nyc_output
 coverage
 bin
-packages/*/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ node_js:
   - 'lts/*'
   - 'node'
 
-script: npm run lint && npm run coverage
+script: npm run lint && npm run check && npm run coverage
 after_success: coveralls-lerna

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,32 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.10.4"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+			"dev": true
+		},
+		"@babel/highlight": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			}
+		},
 		"@evocateur/libnpmaccess": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
@@ -117,15 +143,15 @@
 			}
 		},
 		"@lerna/add": {
-			"version": "3.19.0",
-			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.19.0.tgz",
-			"integrity": "sha512-qzhxPyoczvvT1W0wwCK9I0iJ4B9WR+HzYsusmRuzM3mEhWjowhbuvKEl5BjGYuXc9AvEErM/S0Fm5K0RcuS39Q==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.21.0.tgz",
+			"integrity": "sha512-vhUXXF6SpufBE1EkNEXwz1VLW03f177G9uMOFMQkp6OJ30/PWg4Ekifuz9/3YfgB2/GH8Tu4Lk3O51P2Hskg/A==",
 			"dev": true,
 			"requires": {
 				"@evocateur/pacote": "^9.6.3",
-				"@lerna/bootstrap": "3.18.5",
-				"@lerna/command": "3.18.5",
-				"@lerna/filter-options": "3.18.4",
+				"@lerna/bootstrap": "3.21.0",
+				"@lerna/command": "3.21.0",
+				"@lerna/filter-options": "3.20.0",
 				"@lerna/npm-conf": "3.16.0",
 				"@lerna/validation-error": "3.13.0",
 				"dedent": "^0.7.0",
@@ -135,13 +161,13 @@
 			}
 		},
 		"@lerna/bootstrap": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.18.5.tgz",
-			"integrity": "sha512-9vD/BfCz8YSF2Dx7sHaMVo6Cy33WjLEmoN1yrHgNkHjm7ykWbLHG5wru0f4Y4pvwa0s5Hf76rvT8aJWzGHk9IQ==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.21.0.tgz",
+			"integrity": "sha512-mtNHlXpmvJn6JTu0KcuTTPl2jLsDNud0QacV/h++qsaKbhAaJr/FElNZ5s7MwZFUM3XaDmvWzHKaszeBMHIbBw==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.18.5",
-				"@lerna/filter-options": "3.18.4",
+				"@lerna/command": "3.21.0",
+				"@lerna/filter-options": "3.20.0",
 				"@lerna/has-npm-version": "3.16.5",
 				"@lerna/npm-install": "3.16.5",
 				"@lerna/package-graph": "3.18.5",
@@ -166,13 +192,13 @@
 			}
 		},
 		"@lerna/changed": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.18.5.tgz",
-			"integrity": "sha512-IXS7VZ5VDQUfCsgK56WYxd42luMBxL456cNUf1yBgQ1cy1U2FPVMitIdLN4AcP7bJizdPWeG8yDptf47jN/xVw==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.21.0.tgz",
+			"integrity": "sha512-hzqoyf8MSHVjZp0gfJ7G8jaz+++mgXYiNs9iViQGA8JlN/dnWLI5sWDptEH3/B30Izo+fdVz0S0s7ydVE3pWIw==",
 			"dev": true,
 			"requires": {
-				"@lerna/collect-updates": "3.18.0",
-				"@lerna/command": "3.18.5",
+				"@lerna/collect-updates": "3.20.0",
+				"@lerna/command": "3.21.0",
 				"@lerna/listable": "3.18.5",
 				"@lerna/output": "3.13.0"
 			}
@@ -200,13 +226,13 @@
 			}
 		},
 		"@lerna/clean": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.18.5.tgz",
-			"integrity": "sha512-tHxOj9frTIhB/H2gtgMU3xpIc4IJEhXcUlReko6RJt8TTiDZGPDudCcgjg6i7n15v9jXMOc1y4F+y5/1089bfA==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.21.0.tgz",
+			"integrity": "sha512-b/L9l+MDgE/7oGbrav6rG8RTQvRiZLO1zTcG17zgJAAuhlsPxJExMlh2DFwJEVi2les70vMhHfST3Ue1IMMjpg==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.18.5",
-				"@lerna/filter-options": "3.18.4",
+				"@lerna/command": "3.21.0",
+				"@lerna/filter-options": "3.20.0",
 				"@lerna/prompt": "3.18.5",
 				"@lerna/pulse-till-done": "3.13.0",
 				"@lerna/rimraf-dir": "3.16.5",
@@ -240,9 +266,9 @@
 			}
 		},
 		"@lerna/collect-updates": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.18.0.tgz",
-			"integrity": "sha512-LJMKgWsE/var1RSvpKDIxS8eJ7POADEc0HM3FQiTpEczhP6aZfv9x3wlDjaHpZm9MxJyQilqxZcasRANmRcNgw==",
+			"version": "3.20.0",
+			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.20.0.tgz",
+			"integrity": "sha512-qBTVT5g4fupVhBFuY4nI/3FSJtQVcDh7/gEPOpRxoXB/yCSnT38MFHXWl+y4einLciCjt/+0x6/4AG80fjay2Q==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
@@ -253,14 +279,14 @@
 			}
 		},
 		"@lerna/command": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.18.5.tgz",
-			"integrity": "sha512-36EnqR59yaTU4HrR1C9XDFti2jRx0BgpIUBeWn129LZZB8kAB3ov1/dJNa1KcNRKp91DncoKHLY99FZ6zTNpMQ==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.21.0.tgz",
+			"integrity": "sha512-T2bu6R8R3KkH5YoCKdutKv123iUgUbW8efVjdGCDnCMthAQzoentOJfDeodBwn0P2OqCl3ohsiNVtSn9h78fyQ==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
 				"@lerna/package-graph": "3.18.5",
-				"@lerna/project": "3.18.0",
+				"@lerna/project": "3.21.0",
 				"@lerna/validation-error": "3.13.0",
 				"@lerna/write-log-file": "3.13.0",
 				"clone-deep": "^4.0.1",
@@ -271,9 +297,9 @@
 			}
 		},
 		"@lerna/conventional-commits": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.18.5.tgz",
-			"integrity": "sha512-qcvXIEJ3qSgalxXnQ7Yxp5H9Ta5TVyai6vEor6AAEHc20WiO7UIdbLDCxBtiiHMdGdpH85dTYlsoYUwsCJu3HQ==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.22.0.tgz",
+			"integrity": "sha512-z4ZZk1e8Mhz7+IS8NxHr64wyklHctCJyWpJKEZZPJiLFJ8yKto/x38O80R10pIzC0rr8Sy/OsjSH4bl0TbbgqA==",
 			"dev": true,
 			"requires": {
 				"@lerna/validation-error": "3.13.0",
@@ -290,14 +316,14 @@
 			}
 		},
 		"@lerna/create": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.18.5.tgz",
-			"integrity": "sha512-cHpjocbpKmLopCuZFI7cKEM3E/QY8y+yC7VtZ4FQRSaLU8D8i2xXtXmYaP1GOlVNavji0iwoXjuNpnRMInIr2g==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.22.0.tgz",
+			"integrity": "sha512-MdiQQzCcB4E9fBF1TyMOaAEz9lUjIHp1Ju9H7f3lXze5JK6Fl5NYkouAvsLgY6YSIhXMY8AHW2zzXeBDY4yWkw==",
 			"dev": true,
 			"requires": {
 				"@evocateur/pacote": "^9.6.3",
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.18.5",
+				"@lerna/command": "3.21.0",
 				"@lerna/npm-conf": "3.16.0",
 				"@lerna/validation-error": "3.13.0",
 				"camelcase": "^5.0.0",
@@ -337,38 +363,39 @@
 			}
 		},
 		"@lerna/diff": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.18.5.tgz",
-			"integrity": "sha512-u90lGs+B8DRA9Z/2xX4YaS3h9X6GbypmGV6ITzx9+1Ga12UWGTVlKaCXBgONMBjzJDzAQOK8qPTwLA57SeBLgA==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.21.0.tgz",
+			"integrity": "sha512-5viTR33QV3S7O+bjruo1SaR40m7F2aUHJaDAC7fL9Ca6xji+aw1KFkpCtVlISS0G8vikUREGMJh+c/VMSc8Usw==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.18.5",
+				"@lerna/command": "3.21.0",
 				"@lerna/validation-error": "3.13.0",
 				"npmlog": "^4.1.2"
 			}
 		},
 		"@lerna/exec": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.18.5.tgz",
-			"integrity": "sha512-Q1nz95MeAxctS9bF+aG8FkjixzqEjRpg6ujtnDW84J42GgxedkPtNcJ2o/MBqLd/mxAlr+fW3UZ6CPC/zgoyCg==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.21.0.tgz",
+			"integrity": "sha512-iLvDBrIE6rpdd4GIKTY9mkXyhwsJ2RvQdB9ZU+/NhR3okXfqKc6py/24tV111jqpXTtZUW6HNydT4dMao2hi1Q==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.18.5",
-				"@lerna/filter-options": "3.18.4",
+				"@lerna/command": "3.21.0",
+				"@lerna/filter-options": "3.20.0",
+				"@lerna/profiler": "3.20.0",
 				"@lerna/run-topologically": "3.18.5",
 				"@lerna/validation-error": "3.13.0",
 				"p-map": "^2.1.0"
 			}
 		},
 		"@lerna/filter-options": {
-			"version": "3.18.4",
-			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.18.4.tgz",
-			"integrity": "sha512-4giVQD6tauRwweO/322LP2gfVDOVrt/xN4khkXyfkJDfcsZziFXq+668otD9KSLL8Ps+To4Fah3XbK0MoNuEvA==",
+			"version": "3.20.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.20.0.tgz",
+			"integrity": "sha512-bmcHtvxn7SIl/R9gpiNMVG7yjx7WyT0HSGw34YVZ9B+3xF/83N3r5Rgtjh4hheLZ+Q91Or0Jyu5O3Nr+AwZe2g==",
 			"dev": true,
 			"requires": {
-				"@lerna/collect-updates": "3.18.0",
+				"@lerna/collect-updates": "3.20.0",
 				"@lerna/filter-packages": "3.18.0",
 				"dedent": "^0.7.0",
 				"figgy-pudding": "^3.5.1",
@@ -407,13 +434,13 @@
 			}
 		},
 		"@lerna/github-client": {
-			"version": "3.16.5",
-			"resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.16.5.tgz",
-			"integrity": "sha512-rHQdn8Dv/CJrO3VouOP66zAcJzrHsm+wFuZ4uGAai2At2NkgKH+tpNhQy2H1PSC0Ezj9LxvdaHYrUzULqVK5Hw==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.22.0.tgz",
+			"integrity": "sha512-O/GwPW+Gzr3Eb5bk+nTzTJ3uv+jh5jGho9BOqKlajXaOkMYGBELEAqV5+uARNGWZFvYAiF4PgqHb6aCUu7XdXg==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@octokit/plugin-enterprise-rest": "^3.6.1",
+				"@octokit/plugin-enterprise-rest": "^6.0.1",
 				"@octokit/rest": "^16.28.4",
 				"git-url-parse": "^11.1.2",
 				"npmlog": "^4.1.2"
@@ -447,13 +474,13 @@
 			}
 		},
 		"@lerna/import": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.18.5.tgz",
-			"integrity": "sha512-PH0WVLEgp+ORyNKbGGwUcrueW89K3Iuk/DDCz8mFyG2IG09l/jOF0vzckEyGyz6PO5CMcz4TI1al/qnp3FrahQ==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.22.0.tgz",
+			"integrity": "sha512-uWOlexasM5XR6tXi4YehODtH9Y3OZrFht3mGUFFT3OIl2s+V85xIGFfqFGMTipMPAGb2oF1UBLL48kR43hRsOg==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.18.5",
+				"@lerna/command": "3.21.0",
 				"@lerna/prompt": "3.18.5",
 				"@lerna/pulse-till-done": "3.13.0",
 				"@lerna/validation-error": "3.13.0",
@@ -462,26 +489,37 @@
 				"p-map-series": "^1.0.0"
 			}
 		},
+		"@lerna/info": {
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/info/-/info-3.21.0.tgz",
+			"integrity": "sha512-0XDqGYVBgWxUquFaIptW2bYSIu6jOs1BtkvRTWDDhw4zyEdp6q4eaMvqdSap1CG+7wM5jeLCi6z94wS0AuiuwA==",
+			"dev": true,
+			"requires": {
+				"@lerna/command": "3.21.0",
+				"@lerna/output": "3.13.0",
+				"envinfo": "^7.3.1"
+			}
+		},
 		"@lerna/init": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.18.5.tgz",
-			"integrity": "sha512-oCwipWrha98EcJAHm8AGd2YFFLNI7AW9AWi0/LbClj1+XY9ah+uifXIgYGfTk63LbgophDd8936ZEpHMxBsbAg==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.21.0.tgz",
+			"integrity": "sha512-6CM0z+EFUkFfurwdJCR+LQQF6MqHbYDCBPyhu/d086LRf58GtYZYj49J8mKG9ktayp/TOIxL/pKKjgLD8QBPOg==",
 			"dev": true,
 			"requires": {
 				"@lerna/child-process": "3.16.5",
-				"@lerna/command": "3.18.5",
+				"@lerna/command": "3.21.0",
 				"fs-extra": "^8.1.0",
 				"p-map": "^2.1.0",
 				"write-json-file": "^3.2.0"
 			}
 		},
 		"@lerna/link": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.18.5.tgz",
-			"integrity": "sha512-xTN3vktJpkT7Nqc3QkZRtHO4bT5NvuLMtKNIBDkks0HpGxC9PRyyqwOoCoh1yOGbrWIuDezhfMg3Qow+6I69IQ==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.21.0.tgz",
+			"integrity": "sha512-tGu9GxrX7Ivs+Wl3w1+jrLi1nQ36kNI32dcOssij6bg0oZ2M2MDEFI9UF2gmoypTaN9uO5TSsjCFS7aR79HbdQ==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.18.5",
+				"@lerna/command": "3.21.0",
 				"@lerna/package-graph": "3.18.5",
 				"@lerna/symlink-dependencies": "3.17.0",
 				"p-map": "^2.1.0",
@@ -489,13 +527,13 @@
 			}
 		},
 		"@lerna/list": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.18.5.tgz",
-			"integrity": "sha512-qIeomm28C2OCM8TMjEe/chTnQf6XLN54wPVQ6kZy+axMYxANFNt/uhs6GZEmhem7GEVawzkyHSz5ZJPsfH3IFg==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.21.0.tgz",
+			"integrity": "sha512-KehRjE83B1VaAbRRkRy6jLX1Cin8ltsrQ7FHf2bhwhRHK0S54YuA6LOoBnY/NtA8bHDX/Z+G5sMY78X30NS9tg==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.18.5",
-				"@lerna/filter-options": "3.18.4",
+				"@lerna/command": "3.21.0",
+				"@lerna/filter-options": "3.20.0",
 				"@lerna/listable": "3.18.5",
 				"@lerna/output": "3.13.0"
 			}
@@ -657,10 +695,22 @@
 				"semver": "^6.2.0"
 			}
 		},
+		"@lerna/profiler": {
+			"version": "3.20.0",
+			"resolved": "https://registry.npmjs.org/@lerna/profiler/-/profiler-3.20.0.tgz",
+			"integrity": "sha512-bh8hKxAlm6yu8WEOvbLENm42i2v9SsR4WbrCWSbsmOElx3foRnMlYk7NkGECa+U5c3K4C6GeBbwgqs54PP7Ljg==",
+			"dev": true,
+			"requires": {
+				"figgy-pudding": "^3.5.1",
+				"fs-extra": "^8.1.0",
+				"npmlog": "^4.1.2",
+				"upath": "^1.2.0"
+			}
+		},
 		"@lerna/project": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.18.0.tgz",
-			"integrity": "sha512-+LDwvdAp0BurOAWmeHE3uuticsq9hNxBI0+FMHiIai8jrygpJGahaQrBYWpwbshbQyVLeQgx3+YJdW2TbEdFWA==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.21.0.tgz",
+			"integrity": "sha512-xT1mrpET2BF11CY32uypV2GPtPVm6Hgtha7D81GQP9iAitk9EccrdNjYGt5UBYASl4CIDXBRxwmTTVGfrCx82A==",
 			"dev": true,
 			"requires": {
 				"@lerna/package": "3.16.0",
@@ -688,9 +738,9 @@
 			}
 		},
 		"@lerna/publish": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.18.5.tgz",
-			"integrity": "sha512-ifYqLX6mvw95T8vYRlhT68UC7Al0flQvnf5uF9lDgdrgR5Bs+BTwzk3D+0ctdqMtfooekrV6pqfW0R3gtwRffQ==",
+			"version": "3.22.1",
+			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.22.1.tgz",
+			"integrity": "sha512-PG9CM9HUYDreb1FbJwFg90TCBQooGjj+n/pb3gw/eH5mEDq0p8wKdLFe0qkiqUkm/Ub5C8DbVFertIo0Vd0zcw==",
 			"dev": true,
 			"requires": {
 				"@evocateur/libnpmaccess": "^3.1.2",
@@ -698,8 +748,8 @@
 				"@evocateur/pacote": "^9.6.3",
 				"@lerna/check-working-tree": "3.16.5",
 				"@lerna/child-process": "3.16.5",
-				"@lerna/collect-updates": "3.18.0",
-				"@lerna/command": "3.18.5",
+				"@lerna/collect-updates": "3.20.0",
+				"@lerna/command": "3.21.0",
 				"@lerna/describe-ref": "3.16.5",
 				"@lerna/log-packed": "3.16.0",
 				"@lerna/npm-conf": "3.16.0",
@@ -714,7 +764,7 @@
 				"@lerna/run-lifecycle": "3.16.2",
 				"@lerna/run-topologically": "3.18.5",
 				"@lerna/validation-error": "3.13.0",
-				"@lerna/version": "3.18.5",
+				"@lerna/version": "3.22.1",
 				"figgy-pudding": "^3.5.1",
 				"fs-extra": "^8.1.0",
 				"npm-package-arg": "^6.1.0",
@@ -768,15 +818,16 @@
 			}
 		},
 		"@lerna/run": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.18.5.tgz",
-			"integrity": "sha512-1S0dZccNJO8+gT5ztYE4rHTEnbXVwThHOfDnlVt2KDxl9cbnBALk3xprGLW7lSzJsxegS849hxrAPUh0UorMgw==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.21.0.tgz",
+			"integrity": "sha512-fJF68rT3veh+hkToFsBmUJ9MHc9yGXA7LSDvhziAojzOb0AI/jBDp6cEcDQyJ7dbnplba2Lj02IH61QUf9oW0Q==",
 			"dev": true,
 			"requires": {
-				"@lerna/command": "3.18.5",
-				"@lerna/filter-options": "3.18.4",
+				"@lerna/command": "3.21.0",
+				"@lerna/filter-options": "3.20.0",
 				"@lerna/npm-run-script": "3.16.5",
 				"@lerna/output": "3.13.0",
+				"@lerna/profiler": "3.20.0",
 				"@lerna/run-topologically": "3.18.5",
 				"@lerna/timer": "3.13.0",
 				"@lerna/validation-error": "3.13.0",
@@ -849,17 +900,17 @@
 			}
 		},
 		"@lerna/version": {
-			"version": "3.18.5",
-			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.18.5.tgz",
-			"integrity": "sha512-eSMxLIDuVxZIq0JZKNih50x1IZuMmViwF59uwOGMx0hHB84N3waE8HXOF9CJXDSjeP6sHB8tS+Y+X5fFpBop2Q==",
+			"version": "3.22.1",
+			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.22.1.tgz",
+			"integrity": "sha512-PSGt/K1hVqreAFoi3zjD0VEDupQ2WZVlVIwesrE5GbrL2BjXowjCsTDPqblahDUPy0hp6h7E2kG855yLTp62+g==",
 			"dev": true,
 			"requires": {
 				"@lerna/check-working-tree": "3.16.5",
 				"@lerna/child-process": "3.16.5",
-				"@lerna/collect-updates": "3.18.0",
-				"@lerna/command": "3.18.5",
-				"@lerna/conventional-commits": "3.18.5",
-				"@lerna/github-client": "3.16.5",
+				"@lerna/collect-updates": "3.20.0",
+				"@lerna/command": "3.21.0",
+				"@lerna/conventional-commits": "3.22.0",
+				"@lerna/github-client": "3.22.0",
 				"@lerna/gitlab-client": "3.15.0",
 				"@lerna/output": "3.13.0",
 				"@lerna/prerelease-id-from-version": "3.16.0",
@@ -908,90 +959,166 @@
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
 		},
-		"@octokit/endpoint": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
-			"integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
+		"@octokit/auth-token": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+			"integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^2.0.0",
-				"is-plain-object": "^3.0.0",
-				"universal-user-agent": "^4.0.0"
+				"@octokit/types": "^5.0.0"
+			}
+		},
+		"@octokit/endpoint": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+			"integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^5.0.0",
+				"is-plain-object": "^4.0.0",
+				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
 				"is-plain-object": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-					"dev": true,
-					"requires": {
-						"isobject": "^4.0.0"
-					}
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+					"integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
+					"dev": true
 				},
-				"isobject": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+				"universal-user-agent": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+					"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
 					"dev": true
 				}
 			}
 		},
 		"@octokit/plugin-enterprise-rest": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-3.6.2.tgz",
-			"integrity": "sha512-3wF5eueS5OHQYuAEudkpN+xVeUsg8vYEMMenEzLphUZ7PRZ8OJtDcsreL3ad9zxXmBbaFWzLmFcdob5CLyZftA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-6.0.1.tgz",
+			"integrity": "sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw==",
 			"dev": true
 		},
-		"@octokit/request": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
-			"integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
+		"@octokit/plugin-paginate-rest": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+			"integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
 			"dev": true,
 			"requires": {
-				"@octokit/endpoint": "^5.5.0",
-				"@octokit/request-error": "^1.0.1",
-				"@octokit/types": "^2.0.0",
-				"deprecation": "^2.0.0",
-				"is-plain-object": "^3.0.0",
-				"node-fetch": "^2.3.0",
-				"once": "^1.4.0",
-				"universal-user-agent": "^4.0.0"
+				"@octokit/types": "^2.0.1"
 			},
 			"dependencies": {
-				"is-plain-object": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+				"@octokit/types": {
+					"version": "2.16.2",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+					"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
 					"dev": true,
 					"requires": {
-						"isobject": "^4.0.0"
+						"@types/node": ">= 8"
+					}
+				}
+			}
+		},
+		"@octokit/plugin-request-log": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+			"integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==",
+			"dev": true
+		},
+		"@octokit/plugin-rest-endpoint-methods": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+			"integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^2.0.1",
+				"deprecation": "^2.3.1"
+			},
+			"dependencies": {
+				"@octokit/types": {
+					"version": "2.16.2",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+					"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+					"dev": true,
+					"requires": {
+						"@types/node": ">= 8"
+					}
+				}
+			}
+		},
+		"@octokit/request": {
+			"version": "5.4.7",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+			"integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+			"dev": true,
+			"requires": {
+				"@octokit/endpoint": "^6.0.1",
+				"@octokit/request-error": "^2.0.0",
+				"@octokit/types": "^5.0.0",
+				"deprecation": "^2.0.0",
+				"is-plain-object": "^4.0.0",
+				"node-fetch": "^2.3.0",
+				"once": "^1.4.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"dependencies": {
+				"@octokit/request-error": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+					"integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+					"dev": true,
+					"requires": {
+						"@octokit/types": "^5.0.1",
+						"deprecation": "^2.0.0",
+						"once": "^1.4.0"
 					}
 				},
-				"isobject": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+				"is-plain-object": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+					"integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
+					"dev": true
+				},
+				"universal-user-agent": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+					"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
 					"dev": true
 				}
 			}
 		},
 		"@octokit/request-error": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz",
-			"integrity": "sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+			"integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^2.0.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
+			},
+			"dependencies": {
+				"@octokit/types": {
+					"version": "2.16.2",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+					"integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+					"dev": true,
+					"requires": {
+						"@types/node": ">= 8"
+					}
+				}
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.35.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.35.0.tgz",
-			"integrity": "sha512-9ShFqYWo0CLoGYhA1FdtdykJuMzS/9H6vSbbQWDX4pWr4p9v+15MsH/wpd/3fIU+tSxylaNO48+PIHqOkBRx3w==",
+			"version": "16.43.2",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
+			"integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
 			"dev": true,
 			"requires": {
+				"@octokit/auth-token": "^2.4.0",
+				"@octokit/plugin-paginate-rest": "^1.1.1",
+				"@octokit/plugin-request-log": "^1.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "2.4.0",
 				"@octokit/request": "^5.2.0",
 				"@octokit/request-error": "^1.0.2",
 				"atob-lite": "^2.0.0",
@@ -1007,27 +1134,20 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.2.tgz",
-			"integrity": "sha512-StASIL2lgT3TRjxv17z9pAqbnI7HGu9DrJlg3sEBFfCLaMEqp+O3IQPUF6EZtQ4xkAu2ml6kMBBCtGxjvmtmuQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.2.1.tgz",
+			"integrity": "sha512-PugtgEw8u++zAyBpDpSkR8K1OsT2l8QWp3ECL6bZHFoq9PfHDoKeGFWSuX2Z+Ghy93k1fkKf8tsmqNBv+8dEfQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": ">= 8"
 			}
 		},
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-			"dev": true
-		},
 		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
 			"requires": {
-				"@types/events": "*",
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
@@ -1038,10 +1158,22 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
 			"dev": true
 		},
+		"@types/minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+			"dev": true
+		},
 		"@types/node": {
-			"version": "12.12.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-			"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
+			"version": "14.0.27",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+			"integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
+			"dev": true
+		},
+		"@types/normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
 			"dev": true
 		},
 		"@zkochan/cmd-shim": {
@@ -1090,12 +1222,12 @@
 			}
 		},
 		"ajv": {
-			"version": "6.10.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+			"version": "6.12.3",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+			"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
 			"dev": true,
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
+				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
@@ -1268,9 +1400,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -1350,9 +1482,9 @@
 			"dev": true
 		},
 		"bluebird": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -1425,9 +1557,9 @@
 			"dev": true
 		},
 		"cacache": {
-			"version": "12.0.3",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-			"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+			"version": "12.0.4",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+			"integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.5",
@@ -1501,22 +1633,14 @@
 			"dev": true
 		},
 		"camelcase-keys": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+			"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0",
-				"map-obj": "^2.0.0",
-				"quick-lru": "^1.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				}
+				"camelcase": "^5.3.1",
+				"map-obj": "^4.0.0",
+				"quick-lru": "^4.0.1"
 			}
 		},
 		"caseless": {
@@ -1543,9 +1667,9 @@
 			"dev": true
 		},
 		"chownr": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"dev": true
 		},
 		"ci-info": {
@@ -1587,9 +1711,9 @@
 			}
 		},
 		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
 			"dev": true
 		},
 		"cliui": {
@@ -1704,17 +1828,10 @@
 				"delayed-stream": "~1.0.0"
 			}
 		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true,
-			"optional": true
-		},
 		"compare-func": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
+			"integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
 			"dev": true,
 			"requires": {
 				"array-ify": "^1.0.0",
@@ -1773,9 +1890,9 @@
 			"dev": true
 		},
 		"conventional-changelog-angular": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.6.tgz",
-			"integrity": "sha512-QDEmLa+7qdhVIv8sFZfVxU1VSyVvnXPsxq8Vam49mKUcO1Z8VTLEJk9uI21uiJUsnmm0I4Hrsdc9TgkOQo9WSA==",
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz",
+			"integrity": "sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
@@ -1804,55 +1921,57 @@
 			},
 			"dependencies": {
 				"through2": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+					"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
 					"dev": true,
 					"requires": {
+						"inherits": "^2.0.4",
 						"readable-stream": "2 || 3"
 					}
 				}
 			}
 		},
 		"conventional-changelog-preset-loader": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.0.tgz",
-			"integrity": "sha512-/rHb32J2EJnEXeK4NpDgMaAVTFZS3o1ExmjKMtYVgIC4MQn0vkNSbYpdGRotkfGGRWiqk3Ri3FBkiZGbAfIfOQ==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+			"integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
 			"dev": true
 		},
 		"conventional-changelog-writer": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.11.tgz",
-			"integrity": "sha512-g81GQOR392I+57Cw3IyP1f+f42ME6aEkbR+L7v1FBBWolB0xkjKTeCWVguzRrp6UiT1O6gBpJbEy2eq7AnV1rw==",
+			"version": "4.0.16",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz",
+			"integrity": "sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^1.3.1",
-				"conventional-commits-filter": "^2.0.2",
+				"conventional-commits-filter": "^2.0.6",
 				"dateformat": "^3.0.0",
-				"handlebars": "^4.4.0",
+				"handlebars": "^4.7.6",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.17.15",
-				"meow": "^5.0.0",
+				"meow": "^7.0.0",
 				"semver": "^6.0.0",
 				"split": "^1.0.0",
 				"through2": "^3.0.0"
 			},
 			"dependencies": {
 				"through2": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+					"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
 					"dev": true,
 					"requires": {
+						"inherits": "^2.0.4",
 						"readable-stream": "2 || 3"
 					}
 				}
 			}
 		},
 		"conventional-commits-filter": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
-			"integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.6.tgz",
+			"integrity": "sha512-4g+sw8+KA50/Qwzfr0hL5k5NWxqtrOVw4DDk3/h6L85a9Gz0/Eqp3oP+CWCNfesBvZZZEFHF7OTEbRe+yYSyKw==",
 			"dev": true,
 			"requires": {
 				"lodash.ismatch": "^4.4.0",
@@ -1860,26 +1979,27 @@
 			}
 		},
 		"conventional-commits-parser": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.8.tgz",
-			"integrity": "sha512-YcBSGkZbYp7d+Cr3NWUeXbPDFUN6g3SaSIzOybi8bjHL5IJ5225OSCxJJ4LgziyEJ7AaJtE9L2/EU6H7Nt/DDQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.1.0.tgz",
+			"integrity": "sha512-RSo5S0WIwXZiRxUGTPuYFbqvrR4vpJ1BDdTlthFgvHt5kEdnd1+pdvwWphWn57/oIl4V72NMmOocFqqJ8mFFhA==",
 			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.1",
 				"lodash": "^4.17.15",
-				"meow": "^5.0.0",
+				"meow": "^7.0.0",
 				"split2": "^2.0.0",
 				"through2": "^3.0.0",
 				"trim-off-newlines": "^1.0.0"
 			},
 			"dependencies": {
 				"through2": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+					"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
 					"dev": true,
 					"requires": {
+						"inherits": "^2.0.4",
 						"readable-stream": "2 || 3"
 					}
 				}
@@ -1901,6 +2021,23 @@
 				"q": "^1.5.1"
 			},
 			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
+					}
+				},
 				"concat-stream": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
@@ -1912,6 +2049,18 @@
 						"readable-stream": "^3.0.2",
 						"typedarray": "^0.0.6"
 					}
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"map-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
 				},
 				"meow": {
 					"version": "4.0.1",
@@ -1930,22 +2079,54 @@
 						"trim-newlines": "^2.0.0"
 					}
 				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+				"minimist-options": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+					"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+					"dev": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"is-plain-obj": "^1.1.0"
+					}
+				},
+				"quick-lru": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+					"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
 					"dev": true
 				},
 				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
 						"util-deprecate": "^1.0.1"
 					}
+				},
+				"redent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
+					"requires": {
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
+					}
+				},
+				"strip-indent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
+				},
+				"trim-newlines": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+					"dev": true
 				}
 			}
 		},
@@ -2264,12 +2445,12 @@
 			"dev": true
 		},
 		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
 			"dev": true,
 			"requires": {
-				"iconv-lite": "~0.4.13"
+				"iconv-lite": "^0.6.2"
 			}
 		},
 		"end-of-stream": {
@@ -2282,9 +2463,15 @@
 			}
 		},
 		"env-paths": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
-			"integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+			"dev": true
+		},
+		"envinfo": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.2.tgz",
+			"integrity": "sha512-k3Eh5bKuQnZjm49/L7H4cHzs2FlL5QjbTB3JrPxoTI8aJG7hVMe4uKyJxSYH4ahseby2waUwk5OaKX/nAsaYgg==",
 			"dev": true
 		},
 		"err-code": {
@@ -2303,21 +2490,22 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.16.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-			"integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+			"version": "1.17.6",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.4",
-				"is-regex": "^1.0.4",
+				"is-callable": "^1.2.0",
+				"is-regex": "^1.1.0",
 				"object-inspect": "^1.7.0",
 				"object-keys": "^1.1.1",
-				"string.prototype.trimleft": "^2.1.0",
-				"string.prototype.trimright": "^2.1.0"
+				"object.assign": "^4.1.0",
+				"string.prototype.trimend": "^1.0.1",
+				"string.prototype.trimstart": "^1.0.1"
 			}
 		},
 		"es-to-primitive": {
@@ -2465,6 +2653,17 @@
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
 				"tmp": "^0.0.33"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"dev": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				}
 			}
 		},
 		"extglob": {
@@ -2539,9 +2738,9 @@
 			"dev": true
 		},
 		"fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
 		"fast-glob": {
@@ -2582,15 +2781,15 @@
 			}
 		},
 		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
 		"figgy-pudding": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+			"integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
 			"dev": true
 		},
 		"figures": {
@@ -2832,12 +3031,6 @@
 						"trim-newlines": "^1.0.0"
 					}
 				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
 				"parse-json": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -2979,6 +3172,35 @@
 				"through2": "^2.0.0"
 			},
 			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"map-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
+				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
@@ -2996,10 +3218,42 @@
 						"trim-newlines": "^2.0.0"
 					}
 				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+				"minimist-options": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+					"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+					"dev": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"is-plain-obj": "^1.1.0"
+					}
+				},
+				"quick-lru": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+					"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+					"dev": true
+				},
+				"redent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
+					"requires": {
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
+					}
+				},
+				"strip-indent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
+				},
+				"trim-newlines": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
 					"dev": true
 				}
 			}
@@ -3032,6 +3286,35 @@
 				"semver": "^6.0.0"
 			},
 			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0",
+						"map-obj": "^2.0.0",
+						"quick-lru": "^1.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"map-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+					"dev": true
+				},
 				"meow": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
@@ -3049,10 +3332,42 @@
 						"trim-newlines": "^2.0.0"
 					}
 				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+				"minimist-options": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+					"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+					"dev": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"is-plain-obj": "^1.1.0"
+					}
+				},
+				"quick-lru": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+					"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+					"dev": true
+				},
+				"redent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+					"dev": true,
+					"requires": {
+						"indent-string": "^3.0.0",
+						"strip-indent": "^2.0.0"
+					}
+				},
+				"strip-indent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+					"dev": true
+				},
+				"trim-newlines": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
 					"dev": true
 				}
 			}
@@ -3100,9 +3415,9 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
@@ -3131,21 +3446,22 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-			"integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+			"version": "4.7.6",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+			"integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
 			"dev": true,
 			"requires": {
+				"minimist": "^1.2.5",
 				"neo-async": "^2.6.0",
-				"optimist": "^0.6.1",
 				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -3163,14 +3479,20 @@
 			"dev": true
 		},
 		"har-validator": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.5",
+				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
 			}
+		},
+		"hard-rejection": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.3",
@@ -3232,9 +3554,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
 			"dev": true
 		},
 		"http-cache-semantics": {
@@ -3284,12 +3606,12 @@
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+			"integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}
 		},
 		"iferr": {
@@ -3348,9 +3670,9 @@
 			"dev": true
 		},
 		"indent-string": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
 			"dev": true
 		},
 		"infer-owner": {
@@ -3517,9 +3839,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
 			"dev": true
 		},
 		"is-ci": {
@@ -3552,9 +3874,9 @@
 			}
 		},
 		"is-date-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
 			"dev": true
 		},
 		"is-descriptor": {
@@ -3595,13 +3917,10 @@
 			"dev": true
 		},
 		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
@@ -3662,19 +3981,13 @@
 				"isobject": "^3.0.1"
 			}
 		},
-		"is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
-		},
 		"is-regex": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-ssh": {
@@ -3752,10 +4065,16 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
 		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
 		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -3820,35 +4139,42 @@
 			}
 		},
 		"kind-of": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true
 		},
 		"lerna": {
-			"version": "3.19.0",
-			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.19.0.tgz",
-			"integrity": "sha512-YtMmwEqzWHQCh7Ynk7BvjrZri3EkSeVqTAcwZIqWlv9V/dCfvFPyRqp+2NIjPB5nj1FWXLRH6F05VT/qvzuuOA==",
+			"version": "3.22.1",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.22.1.tgz",
+			"integrity": "sha512-vk1lfVRFm+UuEFA7wkLKeSF7Iz13W+N/vFd48aW2yuS7Kv0RbNm2/qcDPV863056LMfkRlsEe+QYOw3palj5Lg==",
 			"dev": true,
 			"requires": {
-				"@lerna/add": "3.19.0",
-				"@lerna/bootstrap": "3.18.5",
-				"@lerna/changed": "3.18.5",
-				"@lerna/clean": "3.18.5",
+				"@lerna/add": "3.21.0",
+				"@lerna/bootstrap": "3.21.0",
+				"@lerna/changed": "3.21.0",
+				"@lerna/clean": "3.21.0",
 				"@lerna/cli": "3.18.5",
-				"@lerna/create": "3.18.5",
-				"@lerna/diff": "3.18.5",
-				"@lerna/exec": "3.18.5",
-				"@lerna/import": "3.18.5",
-				"@lerna/init": "3.18.5",
-				"@lerna/link": "3.18.5",
-				"@lerna/list": "3.18.5",
-				"@lerna/publish": "3.18.5",
-				"@lerna/run": "3.18.5",
-				"@lerna/version": "3.18.5",
+				"@lerna/create": "3.22.0",
+				"@lerna/diff": "3.21.0",
+				"@lerna/exec": "3.21.0",
+				"@lerna/import": "3.22.0",
+				"@lerna/info": "3.21.0",
+				"@lerna/init": "3.21.0",
+				"@lerna/link": "3.21.0",
+				"@lerna/list": "3.21.0",
+				"@lerna/publish": "3.22.1",
+				"@lerna/run": "3.21.0",
+				"@lerna/version": "3.22.1",
 				"import-local": "^2.0.0",
 				"npmlog": "^4.1.2"
 			}
+		},
+		"lines-and-columns": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+			"dev": true
 		},
 		"load-json-file": {
 			"version": "5.3.0",
@@ -3874,9 +4200,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
 			"dev": true
 		},
 		"lodash._reinterpolate": {
@@ -3960,9 +4286,9 @@
 			}
 		},
 		"macos-release": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
+			"integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
 			"dev": true
 		},
 		"make-dir": {
@@ -4008,9 +4334,9 @@
 			"dev": true
 		},
 		"map-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+			"integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
 			"dev": true
 		},
 		"map-visit": {
@@ -4023,43 +4349,153 @@
 			}
 		},
 		"meow": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-			"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+			"integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^4.0.0",
-				"decamelize-keys": "^1.0.0",
-				"loud-rejection": "^1.0.0",
-				"minimist-options": "^3.0.1",
-				"normalize-package-data": "^2.3.4",
-				"read-pkg-up": "^3.0.0",
-				"redent": "^2.0.0",
-				"trim-newlines": "^2.0.0",
-				"yargs-parser": "^10.0.0"
+				"@types/minimist": "^1.2.0",
+				"arrify": "^2.0.1",
+				"camelcase": "^6.0.0",
+				"camelcase-keys": "^6.2.2",
+				"decamelize-keys": "^1.1.0",
+				"hard-rejection": "^2.1.0",
+				"minimist-options": "^4.0.2",
+				"normalize-package-data": "^2.5.0",
+				"read-pkg-up": "^7.0.1",
+				"redent": "^3.0.0",
+				"trim-newlines": "^3.0.0",
+				"type-fest": "^0.13.1",
+				"yargs-parser": "^18.1.3"
 			},
 			"dependencies": {
+				"arrify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+					"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+					"dev": true
+				},
 				"camelcase": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+					"dev": true
+				},
+				"find-up": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"parse-json": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.8.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+							"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+							"dev": true
+						}
+					}
+				},
+				"type-fest": {
+					"version": "0.13.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
 					"dev": true
 				},
 				"yargs-parser": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "5.3.1",
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+							"dev": true
+						}
 					}
 				}
 			}
 		},
 		"merge2": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true
 		},
 		"micromatch": {
@@ -4084,24 +4520,30 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.25",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-			"integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.42.0"
+				"mime-db": "1.44.0"
 			}
 		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
+		},
+		"min-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
 			"dev": true
 		},
 		"minimatch": {
@@ -4114,19 +4556,20 @@
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
 		"minimist-options": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
 			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0"
+				"is-plain-obj": "^1.1.0",
+				"kind-of": "^6.0.3"
 			}
 		},
 		"minipass": {
@@ -4188,12 +4631,12 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
 			}
 		},
 		"mkdirp-promise": {
@@ -4280,9 +4723,9 @@
 			}
 		},
 		"neo-async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
 		},
 		"nice-try": {
@@ -4298,9 +4741,9 @@
 			"dev": true
 		},
 		"node-fetch-npm": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
-			"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz",
+			"integrity": "sha512-iOuIQDWDyjhv9qSDrj9aq/klt6F9z1p2otB3AV7v3zBDcL/x+OfGsvGQZZCcMZbUf4Ujw1xGNQkjvGnVT22cKg==",
 			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
@@ -4309,39 +4752,40 @@
 			}
 		},
 		"node-gyp": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.5.tgz",
-			"integrity": "sha512-WABl9s4/mqQdZneZHVWVG4TVr6QQJZUC6PAx47ITSk9lreZ1n+7Z9mMAIbA3vnO4J9W20P7LhCxtzfWsAD/KDw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
+			"integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
 			"dev": true,
 			"requires": {
-				"env-paths": "^1.0.0",
-				"glob": "^7.0.3",
-				"graceful-fs": "^4.1.2",
-				"mkdirp": "^0.5.0",
-				"nopt": "2 || 3",
-				"npmlog": "0 || 1 || 2 || 3 || 4",
-				"request": "^2.87.0",
-				"rimraf": "2",
-				"semver": "~5.3.0",
+				"env-paths": "^2.2.0",
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.2.2",
+				"mkdirp": "^0.5.1",
+				"nopt": "^4.0.1",
+				"npmlog": "^4.1.2",
+				"request": "^2.88.0",
+				"rimraf": "^2.6.3",
+				"semver": "^5.7.1",
 				"tar": "^4.4.12",
-				"which": "1"
+				"which": "^1.3.1"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
 			}
 		},
 		"nopt": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
 			"dev": true,
 			"requires": {
-				"abbrev": "1"
+				"abbrev": "1",
+				"osenv": "^0.1.4"
 			}
 		},
 		"normalize-package-data": {
@@ -4371,15 +4815,18 @@
 			"dev": true
 		},
 		"npm-bundled": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
-			"dev": true
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+			"dev": true,
+			"requires": {
+				"npm-normalize-package-bin": "^1.0.1"
+			}
 		},
 		"npm-lifecycle": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.4.tgz",
-			"integrity": "sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
+			"integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
 			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
@@ -4391,6 +4838,12 @@
 				"umask": "^1.1.0",
 				"which": "^1.3.1"
 			}
+		},
+		"npm-normalize-package-bin": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+			"dev": true
 		},
 		"npm-package-arg": {
 			"version": "6.1.1",
@@ -4413,13 +4866,14 @@
 			}
 		},
 		"npm-packlist": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.6.tgz",
-			"integrity": "sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+			"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
 			"dev": true,
 			"requires": {
 				"ignore-walk": "^3.0.1",
-				"npm-bundled": "^1.0.1"
+				"npm-bundled": "^1.0.1",
+				"npm-normalize-package-bin": "^1.0.1"
 			}
 		},
 		"npm-pick-manifest": {
@@ -4512,9 +4966,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
 			"dev": true
 		},
 		"object-keys": {
@@ -4532,14 +4986,26 @@
 				"isobject": "^3.0.0"
 			}
 		},
-		"object.getownpropertydescriptors": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"object.pick": {
@@ -4573,16 +5039,6 @@
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
-			}
-		},
-		"optimist": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
-			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
 			}
 		},
 		"os-homedir": {
@@ -4624,9 +5080,9 @@
 			"dev": true
 		},
 		"p-limit": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
@@ -4889,9 +5345,9 @@
 			}
 		},
 		"psl": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
 		"pump": {
@@ -4946,9 +5402,9 @@
 			"dev": true
 		},
 		"quick-lru": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
 			"dev": true
 		},
 		"read": {
@@ -4970,24 +5426,16 @@
 			}
 		},
 		"read-package-json": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.0.tgz",
-			"integrity": "sha512-KLhu8M1ZZNkMcrq1+0UJbR8Dii8KZUqB0Sha4mOx/bknfKI/fyrQVrG/YIt2UOtG667sD8+ee4EXMM91W9dC+A==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
+			"integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.1.2",
 				"json-parse-better-errors": "^1.0.1",
 				"normalize-package-data": "^2.0.0",
-				"slash": "^1.0.0"
-			},
-			"dependencies": {
-				"slash": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-					"dev": true
-				}
+				"npm-normalize-package-bin": "^1.0.0"
 			}
 		},
 		"read-package-tree": {
@@ -5088,9 +5536,9 @@
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -5123,13 +5571,13 @@
 			}
 		},
 		"redent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
 			"dev": true,
 			"requires": {
-				"indent-string": "^3.0.0",
-				"strip-indent": "^2.0.0"
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
 			}
 		},
 		"regex-not": {
@@ -5164,9 +5612,9 @@
 			}
 		},
 		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -5176,7 +5624,7 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
+				"har-validator": "~5.1.3",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
@@ -5186,7 +5634,7 @@
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
+				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
 			},
@@ -5205,21 +5653,21 @@
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+			"integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.15"
+				"lodash": "^4.17.19"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-			"integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+			"integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
 			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.3",
+				"request-promise-core": "1.1.4",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
 			}
@@ -5237,9 +5685,9 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.0.tgz",
-			"integrity": "sha512-HHZ3hmOrk5SvybTb18xq4Ek2uLqLO5/goFCYUyvn26nWox4hdlKlfC/+dChIZ6qc4ZeYcN9ekTz0yyHsFgumMw==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
@@ -5306,13 +5754,10 @@
 			}
 		},
 		"run-async": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
-			"requires": {
-				"is-promise": "^2.1.0"
-			}
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+			"dev": true
 		},
 		"run-queue": {
 			"version": "1.0.3",
@@ -5324,18 +5769,18 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+			"integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
 		},
 		"safe-buffer": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"dev": true
 		},
 		"safe-regex": {
@@ -5419,9 +5864,9 @@
 			"dev": true
 		},
 		"signal-exit": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
 		"slash": {
@@ -5611,12 +6056,12 @@
 			"dev": true
 		},
 		"source-map-resolve": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+			"integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
 			"dev": true,
 			"requires": {
-				"atob": "^2.1.1",
+				"atob": "^2.1.2",
 				"decode-uri-component": "^0.2.0",
 				"resolve-url": "^0.2.1",
 				"source-map-url": "^0.4.0",
@@ -5630,9 +6075,9 @@
 			"dev": true
 		},
 		"spdx-correct": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -5640,15 +6085,15 @@
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
 			"dev": true
 		},
 		"spdx-expression-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
 			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
@@ -5758,9 +6203,9 @@
 			}
 		},
 		"stream-shift": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
 			"dev": true
 		},
 		"string-width": {
@@ -5774,24 +6219,24 @@
 				"strip-ansi": "^3.0.0"
 			}
 		},
-		"string.prototype.trimleft": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+		"string.prototype.trimend": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+			"integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.17.5"
 			}
 		},
-		"string.prototype.trimright": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+		"string.prototype.trimstart": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+			"integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.17.5"
 			}
 		},
 		"string_decoder": {
@@ -5833,10 +6278,13 @@
 			"dev": true
 		},
 		"strip-indent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-			"dev": true
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+			"dev": true,
+			"requires": {
+				"min-indent": "^1.0.0"
+			}
 		},
 		"strong-log-transformer": {
 			"version": "2.1.0",
@@ -5847,14 +6295,6 @@
 				"duplexer": "^0.1.1",
 				"minimist": "^1.2.0",
 				"through": "^2.3.4"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"supports-color": {
@@ -5916,9 +6356,9 @@
 			"dev": true
 		},
 		"thenify": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-			"integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
 			"dev": true,
 			"requires": {
 				"any-promise": "^1.0.0"
@@ -6001,21 +6441,13 @@
 			}
 		},
 		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"tr46": {
@@ -6028,9 +6460,9 @@
 			}
 		},
 		"trim-newlines": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+			"integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
 			"dev": true
 		},
 		"trim-off-newlines": {
@@ -6040,9 +6472,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
 			"dev": true
 		},
 		"tunnel-agent": {
@@ -6073,24 +6505,11 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
-			"integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+			"integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"commander": "~2.20.3",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"optional": true
-				}
-			}
+			"optional": true
 		},
 		"uid-number": {
 			"version": "0.0.6",
@@ -6135,9 +6554,9 @@
 			}
 		},
 		"universal-user-agent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-			"integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+			"integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
 			"dev": true,
 			"requires": {
 				"os-name": "^3.1.0"
@@ -6189,6 +6608,12 @@
 				}
 			}
 		},
+		"upath": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+			"dev": true
+		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -6225,20 +6650,10 @@
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
-		"util.promisify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
-			}
-		},
 		"uuid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -6322,18 +6737,18 @@
 			}
 		},
 		"windows-release": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
-			"integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
+			"integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
 			"dev": true,
 			"requires": {
 				"execa": "^1.0.0"
 			}
 		},
 		"wordwrap": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
 		},
 		"wrap-ansi": {
@@ -6463,13 +6878,12 @@
 			}
 		},
 		"xml2js": {
-			"version": "0.4.22",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
-			"integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
 			"dev": true,
 			"requires": {
 				"sax": ">=0.6.0",
-				"util.promisify": "~1.0.0",
 				"xmlbuilder": "~11.0.0"
 			}
 		},
@@ -6498,9 +6912,9 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "14.2.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
-			"integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
+			"version": "14.2.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+			"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
 			"dev": true,
 			"requires": {
 				"cliui": "^5.0.0",
@@ -6513,7 +6927,7 @@
 				"string-width": "^3.0.0",
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
-				"yargs-parser": "^15.0.0"
+				"yargs-parser": "^15.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6551,9 +6965,9 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
-			"integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+			"version": "15.0.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+			"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "NODE_ENV=development lerna run --parallel start",
     "clean": "lerna run --parallel clean",
     "lint": "lerna run --parallel lint",
+    "check": "lerna run --parallel check",
     "publish": "lerna publish"
   },
   "devDependencies": {

--- a/packages/blob-to-it/index.js
+++ b/packages/blob-to-it/index.js
@@ -4,12 +4,17 @@
 
 const browserReadableStreamToIt = require('browser-readablestream-to-it')
 
+/**
+ * @param {Blob} blob
+ * @returns {AsyncIterable<Uint8Array>}
+ */
 function blobToIt (blob) {
   if (typeof blob.stream === 'function') {
     return browserReadableStreamToIt(blob.stream())
   }
 
   // firefox < 69 does not support blob.stream()
+  // @ts-ignore - response.body is optional, but in practice it's a stream.
   return browserReadableStreamToIt(new Response(blob).body)
 }
 

--- a/packages/blob-to-it/package.json
+++ b/packages/blob-to-it/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "it-all": "^1.0.2",
-    "mocha": "^8.0.1",
+    "mocha": "8.0.1",
     "playwright-test": "^0.7.1",
     "standard": "^14.3.1"
   },

--- a/packages/blob-to-it/package.json
+++ b/packages/blob-to-it/package.json
@@ -10,9 +10,10 @@
     "test": "playwright-test",
     "lint": "standard",
     "coverage": "playwright-test",
-    "check": "tsc --noEmit",
+    "check": "npm run build:dep:types && tsc --noEmit",
     "build": "npm run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
+    "build:dep:types": "cd node_modules/browser-readablestream-to-it && npm run build:types",
+    "build:types": "npm run build:dep:types && tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",

--- a/packages/blob-to-it/package.json
+++ b/packages/blob-to-it/package.json
@@ -9,7 +9,10 @@
   "scripts": {
     "test": "playwright-test",
     "lint": "standard",
-    "coverage": "playwright-test"
+    "coverage": "playwright-test",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -22,5 +25,13 @@
     "mocha": "^8.0.1",
     "playwright-test": "^0.7.1",
     "standard": "^14.3.1"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/blob-to-it/package.json
+++ b/packages/blob-to-it/package.json
@@ -10,6 +10,7 @@
     "test": "playwright-test",
     "lint": "standard",
     "coverage": "playwright-test",
+    "clean": "rm -rf dist",
     "check": "npm run build:dep:types && tsc --noEmit",
     "build": "npm run build:types",
     "build:dep:types": "cd node_modules/browser-readablestream-to-it && npm run build:types",

--- a/packages/blob-to-it/tsconfig.json
+++ b/packages/blob-to-it/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/browser-readablestream-to-it/index.js
+++ b/packages/browser-readablestream-to-it/index.js
@@ -1,5 +1,10 @@
 'use strict'
 
+/**
+ * @template T
+ * @param {ReadableStream<T>} stream
+ * @returns {AsyncIterable<T>}
+ */
 async function * browserReadableStreamToIt (stream) {
   const reader = stream.getReader()
 

--- a/packages/browser-readablestream-to-it/package.json
+++ b/packages/browser-readablestream-to-it/package.json
@@ -11,6 +11,7 @@
     "lint": "standard",
     "coverage": "playwright-test",
     "check": "tsc --noEmit",
+    "clean": "rm -rf dist",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },

--- a/packages/browser-readablestream-to-it/package.json
+++ b/packages/browser-readablestream-to-it/package.json
@@ -9,7 +9,10 @@
   "scripts": {
     "test": "playwright-test",
     "lint": "standard",
-    "coverage": "playwright-test"
+    "coverage": "playwright-test",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -19,5 +22,13 @@
     "mocha": "^8.0.1",
     "playwright-test": "^0.7.1",
     "standard": "^14.3.1"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/browser-readablestream-to-it/package.json
+++ b/packages/browser-readablestream-to-it/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "it-all": "^1.0.2",
-    "mocha": "^8.0.1",
+    "mocha": "8.0.1",
     "playwright-test": "^0.7.1",
     "standard": "^14.3.1"
   },

--- a/packages/browser-readablestream-to-it/tsconfig.json
+++ b/packages/browser-readablestream-to-it/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-all/README.md
+++ b/packages/it-all/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-all)](https://david-dm.org/achingbrain/it?path=packages/it-all)
 
-> Collects all values from an async iterator and returns them as an array
+> Collects all values from an (async) iterable into an array and returns it.
 
 For when you need a one-liner to collect iterable values.
 

--- a/packages/it-all/index.js
+++ b/packages/it-all/index.js
@@ -1,9 +1,16 @@
 'use strict'
 
-const all = async (iterator) => {
+/**
+ * Collects all values from an (async) iterable into an array and returns it.
+ *
+ * @template T
+ * @param {AsyncIterable<T>|Iterable<T>} source
+ * @returns {Promise<T[]>}
+ */
+const all = async (source) => {
   const arr = []
 
-  for await (const entry of iterator) {
+  for await (const entry of source) {
     arr.push(entry)
   }
 

--- a/packages/it-all/package.json
+++ b/packages/it-all/package.json
@@ -10,13 +10,25 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
   "devDependencies": {
     "ava": "^2.4.0",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-all/package.json
+++ b/packages/it-all/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-all/tsconfig.json
+++ b/packages/it-all/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-batch/README.md
+++ b/packages/it-batch/README.md
@@ -2,7 +2,8 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-batch)](https://david-dm.org/achingbrain/it?path=packages/it-batch)
 
-> Takes an async iterator that emits things and emits them as fixed-size batches
+> Takes an (async) iterable that emits things and returns an async iterable that
+> emits those things in fixed-sized batches.
 
 The final batch may be smaller than the max.
 

--- a/packages/it-batch/README.md
+++ b/packages/it-batch/README.md
@@ -2,8 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-batch)](https://david-dm.org/achingbrain/it?path=packages/it-batch)
 
-> Takes an (async) iterable that emits things and returns an async iterable that
-> emits those things in fixed-sized batches.
+> Takes an (async) iterable that emits things and returns an async iterable that emits those things in fixed-sized batches.
 
 The final batch may be smaller than the max.
 

--- a/packages/it-batch/index.js
+++ b/packages/it-batch/index.js
@@ -1,12 +1,23 @@
 'use strict'
 
+/**
+ * Takes an (async) iterable that emits things and returns an async iterable that
+ * emits those things in fixed-sized batches.
+ *
+ * @template T
+ * @param {AsyncIterable<T>|Iterable<T>} source
+ * @param {number|string} [size=1]
+ * @returns {AsyncIterable<T[]>}
+ */
 async function * batch (source, size) {
+  // @ts-ignore - parseInt expects string
   size = parseInt(size)
 
   if (isNaN(size) || size < 1) {
     size = 1
   }
 
+  /** @type {T[]} */
   let things = []
 
   for await (const thing of source) {

--- a/packages/it-batch/package.json
+++ b/packages/it-batch/package.json
@@ -10,7 +10,10 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -18,6 +21,15 @@
     "ava": "^2.4.0",
     "it-all": "^1.0.2",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-batch/package.json
+++ b/packages/it-batch/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-batch/tsconfig.json
+++ b/packages/it-batch/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-buffer-stream/README.md
+++ b/packages/it-buffer-stream/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-buffer-stream)](https://david-dm.org/achingbrain/it?path=packages/it-buffer-stream)
 
-> An async iterator that emits buffers containing bytes up to a certain length
+> An async iterable that emits buffers containing bytes up to a certain length
 
 ## Install
 

--- a/packages/it-buffer-stream/index.js
+++ b/packages/it-buffer-stream/index.js
@@ -1,13 +1,29 @@
 'use strict'
 
+// @ts-ignore - untyped dependency
 const randomBytes = require('iso-random-stream/src/random')
 
+/**
+ * @typedef {Object} Options
+ * @property {number} [chunkSize]
+ * @property {function(Buffer):void} [collector]
+ * @property {function(number):Promise<Buffer>|Buffer} [generator]
+ */
+
+/** @type {Options} */
 const defaultOptions = {
   chunkSize: 4096,
   collector: () => {},
   generator: (size) => Promise.resolve(randomBytes(size))
 }
 
+/**
+ * An async iterable that emits buffers containing bytes up to a certain length.
+ *
+ * @param {number} limit
+ * @param {Options} [options]
+ * @returns {AsyncIterable<Buffer>}
+ */
 async function * bufferStream (limit, options = {}) {
   options = Object.assign({}, defaultOptions, options)
   let emitted = 0

--- a/packages/it-buffer-stream/package.json
+++ b/packages/it-buffer-stream/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-buffer-stream/package.json
+++ b/packages/it-buffer-stream/package.json
@@ -10,7 +10,10 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -18,9 +21,18 @@
     "ava": "^2.4.0",
     "buffer": "^5.5.0",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "iso-random-stream": "^1.1.1"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-buffer-stream/tsconfig.json
+++ b/packages/it-buffer-stream/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-drain/README.md
+++ b/packages/it-drain/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-drain)](https://david-dm.org/achingbrain/it?path=packages/it-drain)
 
-> Drains an async iterator without returning anything
+> Drains an (async) iterable discarding its' content and does not return anything.
 
 Mostly useful for tests or when you want to be explicit about consuming an iterable without doing anything with any yielded values.
 

--- a/packages/it-drain/README.md
+++ b/packages/it-drain/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-drain)](https://david-dm.org/achingbrain/it?path=packages/it-drain)
 
-> Drains an (async) iterable discarding its' content and does not return anything.
+> Drains an (async) iterable discarding its content and does not return anything.
 
 Mostly useful for tests or when you want to be explicit about consuming an iterable without doing anything with any yielded values.
 

--- a/packages/it-drain/index.js
+++ b/packages/it-drain/index.js
@@ -1,7 +1,15 @@
 'use strict'
 
-const drain = async (iterator) => {
-  for await (const _ of iterator) { } // eslint-disable-line no-unused-vars
+/**
+ * Drains an (async) iterable discarding its' content and does not return
+ * anything.
+ *
+ * @template T
+ * @param {AsyncIterable<T>|Iterable<T>} source
+ * @returns {Promise<void>}
+ */
+const drain = async (source) => {
+  for await (const _ of source) { } // eslint-disable-line no-unused-vars
 }
 
 module.exports = drain

--- a/packages/it-drain/package.json
+++ b/packages/it-drain/package.json
@@ -10,13 +10,25 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
   "devDependencies": {
     "ava": "^2.4.0",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-drain/package.json
+++ b/packages/it-drain/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-drain/tsconfig.json
+++ b/packages/it-drain/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-filter/README.md
+++ b/packages/it-filter/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-all)](https://david-dm.org/achingbrain/it?path=packages/it-all)
 
-> Filters the passed iterable by using the filter function
+> Filters the passed (async) iterable by using the filter function
 
 ## Install
 

--- a/packages/it-filter/index.js
+++ b/packages/it-filter/index.js
@@ -1,7 +1,14 @@
 'use strict'
 
-const filter = async function * (iterator, fn) {
-  for await (const entry of iterator) {
+/**
+ * Filters the passed (async) iterable by using the filter function
+ *
+ * @template T
+ * @param {AsyncIterable<T>|Iterable<T>} source
+ * @param {function(T):boolean|Promise<boolean>} fn
+ */
+const filter = async function * (source, fn) {
+  for await (const entry of source) {
     if (await fn(entry)) {
       yield entry
     }

--- a/packages/it-filter/package.json
+++ b/packages/it-filter/package.json
@@ -10,7 +10,10 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -18,6 +21,15 @@
     "ava": "^2.4.0",
     "it-all": "^1.0.2",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-filter/package.json
+++ b/packages/it-filter/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-filter/tsconfig.json
+++ b/packages/it-filter/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-first/README.md
+++ b/packages/it-first/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-first)](https://david-dm.org/achingbrain/it?path=packages/it-first)
 
-> Returns the first result from an async iterator
+> Returns the first result from an (async) iterable.
 
 Mostly useful for tests.
 

--- a/packages/it-first/index.js
+++ b/packages/it-first/index.js
@@ -1,7 +1,15 @@
 'use strict'
 
-const first = async (iterator) => {
-  for await (const entry of iterator) {
+/**
+ * Returns the first result from an (async) iterable, unless empty, in which
+ * case returns `void`.
+ *
+ * @template T
+ * @param {AsyncIterable<T>|Iterable<T>} source
+ * @returns {Promise<T|void>}
+ */
+const first = async (source) => {
+  for await (const entry of source) {
     return entry
   }
 }

--- a/packages/it-first/index.js
+++ b/packages/it-first/index.js
@@ -2,7 +2,7 @@
 
 /**
  * Returns the first result from an (async) iterable, unless empty, in which
- * case returns `void`.
+ * case returns `undefined`.
  *
  * @template T
  * @param {AsyncIterable<T>|Iterable<T>} source

--- a/packages/it-first/package.json
+++ b/packages/it-first/package.json
@@ -10,13 +10,25 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
   "devDependencies": {
     "ava": "^2.4.0",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-first/package.json
+++ b/packages/it-first/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-first/tsconfig.json
+++ b/packages/it-first/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-flat-batch/README.md
+++ b/packages/it-flat-batch/README.md
@@ -2,9 +2,10 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-flat-batch)](https://david-dm.org/achingbrain/it?path=packages/it-flat-batch)
 
-> Takes an async iterator that emits variable length arrays and emits them as fixed-size batches
+> Takes an (async) iterable that emits variable length arrays of things and
+> returns an async iterable that emits those thnigs in fixed-size batches.
 
-The final batch may be smaller than the max.
+The final batch may be smaller than requested batch size.
 
 ## Install
 

--- a/packages/it-flat-batch/README.md
+++ b/packages/it-flat-batch/README.md
@@ -2,8 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-flat-batch)](https://david-dm.org/achingbrain/it?path=packages/it-flat-batch)
 
-> Takes an (async) iterable that emits variable length arrays of things and
-> returns an async iterable that emits those thnigs in fixed-size batches.
+> Takes an (async) iterable that emits variable length arrays of things and returns an async iterable that emits those thnigs in fixed-size batches.
 
 The final batch may be smaller than requested batch size.
 

--- a/packages/it-flat-batch/index.js
+++ b/packages/it-flat-batch/index.js
@@ -2,7 +2,7 @@
 
 /**
  * Takes an (async) iterable that emits variable length arrays of things and
- * returns an async iterable that emits those thnigs in fixed-size batches.
+ * returns an async iterable that emits those things in fixed-size batches.
  *
  * @template T
  * @param {AsyncIterable<T[]>|Iterable<T[]>|AsyncIterable<T>|Iterable<T>} source

--- a/packages/it-flat-batch/index.js
+++ b/packages/it-flat-batch/index.js
@@ -1,12 +1,23 @@
 'use strict'
 
-async function * batch (source, size) {
-  size = parseInt(size)
+/**
+ * Takes an (async) iterable that emits variable length arrays of things and
+ * returns an async iterable that emits those thnigs in fixed-size batches.
+ *
+ * @template T
+ * @param {AsyncIterable<T[]>|Iterable<T[]>|AsyncIterable<T>|Iterable<T>} source
+ * @param {number|string} [batchSize=1]
+ * @returns {AsyncIterable<T[]>}
+ */
+async function * batch (source, batchSize) {
+  // @ts-ignore - expects string not a number
+  let size = parseInt(batchSize)
 
   if (isNaN(size) || size < 1) {
     size = 1
   }
 
+  /** @type {T[]} */
   let things = []
 
   for await (const set of source) {

--- a/packages/it-flat-batch/index.js
+++ b/packages/it-flat-batch/index.js
@@ -5,7 +5,7 @@
  * returns an async iterable that emits those things in fixed-size batches.
  *
  * @template T
- * @param {AsyncIterable<T[]>|Iterable<T[]>|AsyncIterable<T>|Iterable<T>} source
+ * @param {AsyncIterable<T[]>|Iterable<T[]>} source
  * @param {number|string} [batchSize=1]
  * @returns {AsyncIterable<T[]>}
  */

--- a/packages/it-flat-batch/package.json
+++ b/packages/it-flat-batch/package.json
@@ -10,7 +10,10 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -18,6 +21,15 @@
     "ava": "^2.4.0",
     "it-all": "^1.0.2",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-flat-batch/package.json
+++ b/packages/it-flat-batch/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-flat-batch/tsconfig.json
+++ b/packages/it-flat-batch/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-glob/index.js
+++ b/packages/it-glob/index.js
@@ -1,9 +1,29 @@
 'use strict'
 
+// @ts-ignore
 const fs = require('fs-extra')
 const path = require('path')
 const minimatch = require('minimatch')
 
+/**
+ * @typedef {string} Glob
+ * @typedef {Object} OptionsExt
+ * @property {Glob[]} [ignore] - Glob patterns to ignore
+ * @property {string} [cwd=process.cwd()]
+ * @property {boolean} [absolute=false] - If true produces absolute paths
+ * @property {boolean} [nodir] - If true yields file paths and skip directories
+ *
+ * @typedef {OptionsExt & minimatch.IOptions} Options
+ */
+
+/**
+ * Async iterable filename pattern matcher
+ *
+ * @param {string} dir
+ * @param {string} pattern
+ * @param {Options} [options]
+ * @returns {AsyncIterable<string>}
+ */
 module.exports = async function * glob (dir, pattern, options = {}) {
   const absoluteDir = path.resolve(dir)
   const relativeDir = path.relative(options.cwd || process.cwd(), dir)
@@ -23,6 +43,13 @@ module.exports = async function * glob (dir, pattern, options = {}) {
   }
 }
 
+/**
+ * @param {string} base
+ * @param {string} dir
+ * @param {Glob} pattern
+ * @param {Options} options
+ * @returns {AsyncIterable<string>}
+ */
 async function * _glob (base, dir, pattern, options) {
   for await (const entry of await fs.readdir(path.join(base, dir))) {
     const relativeEntryPath = path.join(dir, entry)

--- a/packages/it-glob/package.json
+++ b/packages/it-glob/package.json
@@ -10,7 +10,10 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -22,9 +25,18 @@
     "ava": "^2.4.0",
     "it-all": "^1.0.2",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
   },
   "browser": {
     "fs-extra": false
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-glob/package.json
+++ b/packages/it-glob/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-glob/tsconfig.json
+++ b/packages/it-glob/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-last/README.md
+++ b/packages/it-last/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-last)](https://david-dm.org/achingbrain/it?path=packages/it-last)
 
-> Returns the last result from an async iterator
+> Returns the last item of an (async) iterable
 
 Mostly useful for tests.
 

--- a/packages/it-last/index.js
+++ b/packages/it-last/index.js
@@ -1,9 +1,18 @@
 'use strict'
 
-const last = async (iterator) => {
+/**
+ * Returns the last item of an (async) iterable, unless empty, in which case
+ * return `void`.
+ *
+ * @template T
+ * @param {AsyncIterable<T>|Iterable<T>} source
+ * @returns {Promise<T|void>}
+ */
+const last = async (source) => {
+  /** @type {T|void} */
   let res
 
-  for await (const entry of iterator) {
+  for await (const entry of source) {
     res = entry
   }
 

--- a/packages/it-last/package.json
+++ b/packages/it-last/package.json
@@ -10,13 +10,25 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
   "devDependencies": {
     "ava": "^2.4.0",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-last/package.json
+++ b/packages/it-last/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-last/tsconfig.json
+++ b/packages/it-last/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-map/README.md
+++ b/packages/it-map/README.md
@@ -3,7 +3,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-map)](https://david-dm.org/achingbrain/it?path=packages/it-map)
 
-> Maps the values yielded by an async iterator
+> Maps the values yielded by an (async) iterator
 
 ## Install
 

--- a/packages/it-map/index.js
+++ b/packages/it-map/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /**
- * Takes an (async) iterable and return one with each item mapped with given
+ * Takes an (async) iterable and returns one with each item mapped by the passed
  * function.
  *
  * @template I,O

--- a/packages/it-map/index.js
+++ b/packages/it-map/index.js
@@ -1,7 +1,16 @@
 'use strict'
 
-const map = async function * (iterator, func) {
-  for await (const val of iterator) {
+/**
+ * Takes an (async) iterable and return one with each item mapped with given
+ * function.
+ *
+ * @template I,O
+ * @param {AsyncIterable<I>|Iterable<I>} source
+ * @param {function(I):O|Promise<O>} func
+ * @returns {AsyncIterable<O>}
+ */
+const map = async function * (source, func) {
+  for await (const val of source) {
     yield func(val)
   }
 }

--- a/packages/it-map/package.json
+++ b/packages/it-map/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-map/package.json
+++ b/packages/it-map/package.json
@@ -10,14 +10,26 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
   "devDependencies": {
     "ava": "^2.4.0",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   },
   "gitHead": "42faa5aeb9de0e07c956d73020bd74fd08e3029d"
 }

--- a/packages/it-map/tsconfig.json
+++ b/packages/it-map/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-multipart/index.js
+++ b/packages/it-multipart/index.js
@@ -69,7 +69,7 @@ async function * multipart (source, boundary) {
 }
 
 /**
- * yield chunks of buffer until a the needle is reached. consume the needle
+ * Yield chunks of haystack until the needle is reached. Consume the needle
  * without yielding it
  * @param {PrefixStream<Buffer>} haystack
  * @param {Buffer} needle

--- a/packages/it-multipart/index.js
+++ b/packages/it-multipart/index.js
@@ -197,6 +197,13 @@ function waitForStreamToBeConsumed (stream) {
 
         return next
       } catch (err) {
+        // By rejecting `completion` propagate error to the
+        // A. `for await (cons part of multipart(...))`
+        // By throwing we propagate error to the
+        // B. `for await (const chunk of part.body)`
+        // We need to do both because if we just do A. error will not appear to
+        // the consumer of `part.body`, furthermore A might break a loop before
+        // completion and error may get swallowed.
         pending.reject(err)
         throw err
       }

--- a/packages/it-multipart/package.json
+++ b/packages/it-multipart/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-multipart/package.json
+++ b/packages/it-multipart/package.json
@@ -10,7 +10,10 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -24,6 +27,15 @@
     "form-data": "^2.5.0",
     "node-fetch": "^2.6.0",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-multipart/test.js
+++ b/packages/it-multipart/test.js
@@ -1,17 +1,25 @@
 import test from 'ava'
 import http from 'http'
 import handler from '.'
+// @ts-ignore
 import fetch from 'node-fetch'
 import FormData from 'form-data'
 
+/** @type {string} */
 let port
+/** @type {import('http').Server} */
 let server
 
 test.before.cb((t) => {
+  /**
+   * @param {import('http').IncomingMessage} req
+   */
   async function echo (req) {
+    /** @type {Record<string, string>} */
     const files = {}
 
     for await (const part of handler(req)) {
+      // @ts-ignore - header may not be present
       const name = part.headers['content-disposition'].match(/name="(.*)"/)[1]
 
       files[name] = ''
@@ -26,7 +34,9 @@ test.before.cb((t) => {
 
   server = http.createServer((req, res) => {
     if (req.method === 'POST' &&
+      // @ts-ignore - header may not be present
       req.headers['content-type'].includes('multipart/form-data') &&
+      // @ts-ignore - header may not be present
       req.headers['content-type'].includes('boundary=')
     ) {
       echo(req)
@@ -50,6 +60,7 @@ test.before.cb((t) => {
     res.writeHead(404)
     res.end()
   }).listen(() => {
+    // @ts-ignore - could be null
     port = server.address().port
     t.end()
   })
@@ -108,6 +119,7 @@ test('it parses loads of files from multipart requests', async (t) => {
 
 test('it throws if not handed a multipart request', async (t) => {
   await t.throwsAsync(async () => {
+    // @ts-ignore
     for await (const _ of handler()) { // eslint-disable-line no-unused-vars
 
     }

--- a/packages/it-multipart/test.js
+++ b/packages/it-multipart/test.js
@@ -33,11 +33,10 @@ test.before.cb((t) => {
   }
 
   server = http.createServer((req, res) => {
+    const contentType = req.headers['content-type'] || ''
     if (req.method === 'POST' &&
-      // @ts-ignore - header may not be present
-      req.headers['content-type'].includes('multipart/form-data') &&
-      // @ts-ignore - header may not be present
-      req.headers['content-type'].includes('boundary=')
+      contentType.includes('multipart/form-data') &&
+      contentType.includes('boundary=')
     ) {
       echo(req)
         .then((files) => {
@@ -60,7 +59,8 @@ test.before.cb((t) => {
     res.writeHead(404)
     res.end()
   }).listen(() => {
-    // @ts-ignore - could be null
+    // @ts-ignore - address() returns `null|string|object` and TS can't infer
+    // it's last one even though it's inside listen callback.
     port = server.address().port
     t.end()
   })
@@ -119,7 +119,6 @@ test('it parses loads of files from multipart requests', async (t) => {
 
 test('it throws if not handed a multipart request', async (t) => {
   await t.throwsAsync(async () => {
-    // @ts-ignore
     for await (const _ of handler()) { // eslint-disable-line no-unused-vars
 
     }

--- a/packages/it-multipart/tsconfig.json
+++ b/packages/it-multipart/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-parallel-batch/README.md
+++ b/packages/it-parallel-batch/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-parallel-batch)](https://david-dm.org/achingbrain/it?path=packages/it-parallel-batch)
 
-> Takes an async iterator that emits promise-returning functions, invokes them in parallel and emits the results as they become available but in the same order as the input
+> Takes an (async) iterable that emits promise-returning functions, invokes them in parallel and emits the results as they become available but in the same order as the input
 
 The final batch may be smaller than the batch size.
 

--- a/packages/it-parallel-batch/index.js
+++ b/packages/it-parallel-batch/index.js
@@ -2,26 +2,43 @@
 
 const batch = require('it-batch')
 
+/**
+ * @template T
+ * @typedef {function():Promise<T>} Task
+ */
+
+/**
+ * Takes an (async) iterator that emits promise-returning functions,
+ * invokes them in parallel and emits the results as they become available but
+ * in the same order as the input
+ *
+ * @template T
+ * @param {AsyncIterable<Task<T>>} source
+ * @param {number|string} [size=1]
+ * @returns {AsyncIterable<T>}
+ */
 async function * parallelBatch (source, size) {
+  // @ts-ignore - expects string not a number
   size = parseInt(size)
 
   if (isNaN(size) || size < 1) {
     size = 1
   }
 
-  for await (let things of batch(source, size)) {
-    things = things.map(p => {
-      return p().then(res => ({ res }), err => ({ err }))
+  for await (const tasks of batch(source, size)) {
+    /** @type {Promise<{ok:true, value:T}|{ok:false, err:Error}>[]} */
+    const things = tasks.map(p => {
+      return p().then(value => ({ ok: true, value }), err => ({ ok: false, err }))
     })
 
     for (let i = 0; i < things.length; i++) {
-      const { res, err } = await things[i]
+      const result = await things[i]
 
-      if (err) {
-        throw err
+      if (result.ok) {
+        yield result.value
+      } else {
+        throw result.err
       }
-
-      yield res
     }
   }
 }

--- a/packages/it-parallel-batch/package.json
+++ b/packages/it-parallel-batch/package.json
@@ -12,8 +12,8 @@
     "coverage": "nyc --reporter html --reporter lcov ava",
     "clean": "rm -rf .nyc_output coverage",
     "check": "npm run build:dep:types && tsc --noEmit",
-    "build": "npm run build:dep:types && npm run build:types",
-    "build:dep:types": "cd ../it-batch && npm run build:types",
+    "build": "npm run build:types",
+    "build:dep:types": "cd node_modules/it-batch && npm run build:types",
     "build:types": "npm run build:dep:types && tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",

--- a/packages/it-parallel-batch/package.json
+++ b/packages/it-parallel-batch/package.json
@@ -10,7 +10,10 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -19,9 +22,18 @@
     "delay": "^4.3.0",
     "it-all": "^1.0.2",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "it-batch": "^1.0.4"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-parallel-batch/package.json
+++ b/packages/it-parallel-batch/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "npm run build:dep:types && tsc --noEmit",
     "build": "npm run build:types",
     "build:dep:types": "cd node_modules/it-batch && npm run build:types",

--- a/packages/it-parallel-batch/package.json
+++ b/packages/it-parallel-batch/package.json
@@ -11,9 +11,10 @@
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
     "clean": "rm -rf .nyc_output coverage",
-    "check": "tsc --noEmit",
-    "build": "npm run build:types",
-    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
+    "check": "npm run build:dep:types && tsc --noEmit",
+    "build": "npm run build:dep:types && npm run build:types",
+    "build:dep:types": "cd ../it-batch && npm run build:types",
+    "build:types": "npm run build:dep:types && tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",

--- a/packages/it-parallel-batch/tsconfig.json
+++ b/packages/it-parallel-batch/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-peekable/index.js
+++ b/packages/it-peekable/index.js
@@ -1,10 +1,56 @@
 'use strict'
 
+/**
+ * @template T
+ * @typedef {Object} Peek
+ * @property {() => IteratorResult<T, void>} peek
+ */
+
+/**
+ * @template T
+ * @typedef {Object} AsyncPeek
+ * @property {() => Promise<IteratorResult<T, void>>} peek
+ */
+
+/**
+ * @template T
+ * @typedef {Object} Push
+ * @property {(value:T) => void} push
+ */
+
+/**
+ * @template T
+ * @typedef {Iterable<T> & Peek<T> & Push<T> & Iterator<T>} Peekable<T>
+ */
+
+/**
+ * @template T
+ * @typedef {AsyncIterable<T> & AsyncPeek<T> & Push<T> & AsyncIterator<T>} AsyncPeekable<T>
+ */
+
+/**
+ * @template {Iterable<any> | AsyncIterable<any>} I
+ * @param {I} iterable
+ * @returns {I extends Iterable<infer T>
+ *  ? Peekable<T>
+ *  : I extends AsyncIterable<infer T>
+ *  ? AsyncPeekable<T>
+ *  : never
+ * }
+ */
 function peekableIterator (iterable) {
-  const iterator = iterable[Symbol.asyncIterator] ? iterable[Symbol.asyncIterator]() : iterable[Symbol.iterator]()
+  // @ts-ignore
+  const [iterator, symbol] = iterable[Symbol.asyncIterator]
+    // @ts-ignore
+    ? [iterable[Symbol.asyncIterator](), Symbol.asyncIterator]
+    // @ts-ignore
+    : [iterable[Symbol.iterator](), Symbol.iterator]
+
+  /** @type {any[]} */
   const queue = []
 
-  const peekable = {
+  // @ts-ignore
+  return {
     peek: () => {
       return iterator.next()
     },
@@ -20,20 +66,11 @@ function peekableIterator (iterable) {
       }
 
       return iterator.next()
+    },
+    [symbol] () {
+      return this
     }
   }
-
-  if (iterable[Symbol.asyncIterator]) {
-    peekable[Symbol.asyncIterator] = () => {
-      return peekable
-    }
-  } else {
-    peekable[Symbol.iterator] = () => {
-      return peekable
-    }
-  }
-
-  return peekable
 }
 
 module.exports = peekableIterator

--- a/packages/it-peekable/package.json
+++ b/packages/it-peekable/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-peekable/package.json
+++ b/packages/it-peekable/package.json
@@ -10,7 +10,10 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -19,5 +22,13 @@
     "it-all": "^1.0.2",
     "nyc": "^14.0.0",
     "standard": "^14.3.1"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-peekable/tsconfig.json
+++ b/packages/it-peekable/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-reduce/README.md
+++ b/packages/it-reduce/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-reduce)](https://david-dm.org/achingbrain/it?path=packages/it-reduce)
 
-> Reduces the values yielded by an async iterator
+> Reduces the values yielded by an (async) iterable
 
 Mostly useful for tests or when you want to be explicit about consuming an iterable without doing anything with any yielded values.
 

--- a/packages/it-reduce/index.js
+++ b/packages/it-reduce/index.js
@@ -1,7 +1,15 @@
 'use strict'
 
-const reduce = async (iterator, func, init) => {
-  for await (const val of iterator) {
+/**
+ * Reduces the values yielded by an (async) iterable
+ *
+ * @template T, V
+ * @param {AsyncIterable<T>|Iterable<T>} source
+ * @param {function(V, T):V} func
+ * @param {V} init
+ */
+const reduce = async (source, func, init) => {
+  for await (const val of source) {
     init = func(init, val)
   }
 

--- a/packages/it-reduce/package.json
+++ b/packages/it-reduce/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-reduce/package.json
+++ b/packages/it-reduce/package.json
@@ -10,14 +10,26 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
   "devDependencies": {
     "ava": "^2.4.0",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   },
   "gitHead": "42faa5aeb9de0e07c956d73020bd74fd08e3029d"
 }

--- a/packages/it-reduce/tsconfig.json
+++ b/packages/it-reduce/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-to-browser-readablestream/index.js
+++ b/packages/it-to-browser-readablestream/index.js
@@ -1,9 +1,19 @@
 'use strict'
 
+/** @type {typeof window} */
+// @ts-ignore
 const globalThis = require('@ungap/global-this')
 
+/**
+ * @template T
+ * @param {AsyncIterator<T>|Iterator<T>} source
+ * @param {QueuingStrategy<T>} [queuingStrategy]
+ * @returns {ReadableStream<T>}
+ */
 function itToBrowserReadableStream (source, queuingStrategy = {}) {
-  return new globalThis.ReadableStream({
+  /** @type {UnderlyingSource<T> & { _cancelled:boolean} } */
+  const pump = {
+    _cancelled: false,
     async start () {
       this._cancelled = false
     },
@@ -28,7 +38,9 @@ function itToBrowserReadableStream (source, queuingStrategy = {}) {
     cancel () {
       this._cancelled = true
     }
-  }, queuingStrategy)
+  }
+
+  return new globalThis.ReadableStream(pump, queuingStrategy)
 }
 
 module.exports = itToBrowserReadableStream

--- a/packages/it-to-browser-readablestream/index.js
+++ b/packages/it-to-browser-readablestream/index.js
@@ -5,15 +5,22 @@
 const globalThis = require('@ungap/global-this')
 
 /**
+ * @typedef {Object} SourceExt
+ * @property {boolean} [_cancelled]
+ */
+/**
+ * @template T
+ * @typedef {SourceExt & UnderlyingSource<T>} Source
+ */
+
+/**
  * @template T
  * @param {AsyncIterator<T>|Iterator<T>} source
  * @param {QueuingStrategy<T>} [queuingStrategy]
  * @returns {ReadableStream<T>}
  */
 function itToBrowserReadableStream (source, queuingStrategy = {}) {
-  /** @type {UnderlyingSource<T> & { _cancelled:boolean} } */
-  const pump = {
-    _cancelled: false,
+  return new globalThis.ReadableStream(/** @type {Source<T>} */({
     async start () {
       this._cancelled = false
     },
@@ -38,9 +45,7 @@ function itToBrowserReadableStream (source, queuingStrategy = {}) {
     cancel () {
       this._cancelled = true
     }
-  }
-
-  return new globalThis.ReadableStream(pump, queuingStrategy)
+  }), queuingStrategy)
 }
 
 module.exports = itToBrowserReadableStream

--- a/packages/it-to-browser-readablestream/package.json
+++ b/packages/it-to-browser-readablestream/package.json
@@ -10,7 +10,10 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
@@ -21,5 +24,13 @@
   },
   "dependencies": {
     "@ungap/global-this": "^0.3.1"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-to-browser-readablestream/package.json
+++ b/packages/it-to-browser-readablestream/package.json
@@ -10,7 +10,7 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage",
+    "clean": "rm -rf .nyc_output coverage dist",
     "check": "tsc --noEmit",
     "build": "npm run build:types",
     "build:types": "tsc --emitDeclarationOnly --declarationDir dist"

--- a/packages/it-to-browser-readablestream/tsconfig.json
+++ b/packages/it-to-browser-readablestream/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/packages/it-to-buffer/index.js
+++ b/packages/it-to-buffer/index.js
@@ -2,6 +2,12 @@
 
 const { Buffer } = require('buffer')
 
+/**
+ * Takes an (async) iterable that yields buffer-like-objects and concats them
+ * into one buffer
+ * @param {AsyncIterable<Buffer>|Iterable<Buffer>} stream
+ * @returns {Promise<Buffer>}
+ */
 async function toBuffer (stream) {
   let buffer = Buffer.alloc(0)
 

--- a/packages/it-to-buffer/package.json
+++ b/packages/it-to-buffer/package.json
@@ -10,16 +10,28 @@
     "test": "ava",
     "lint": "standard",
     "coverage": "nyc --reporter html --reporter lcov ava",
-    "clean": "rm -rf .nyc_output coverage"
+    "clean": "rm -rf .nyc_output coverage",
+    "check": "tsc --noEmit",
+    "build": "npm run build:types",
+    "build:types": "tsc --emitDeclarationOnly --declarationDir dist"
   },
   "author": "Alex Potsides <alex@achingbrain.net>",
   "license": "ISC",
   "devDependencies": {
     "ava": "^2.4.0",
     "nyc": "^14.0.0",
-    "standard": "^14.3.1"
+    "standard": "^14.3.1",
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "buffer": "^5.5.0"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        ".",
+        "dist/*"
+      ]
+    }
   }
 }

--- a/packages/it-to-buffer/tsconfig.json
+++ b/packages/it-to-buffer/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../typescript.json",
+  "include": [
+    "."
+  ]
+}

--- a/typescript.json
+++ b/typescript.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "strict": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "target": "ES2018",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  },
+  "include": [],
+  "baseUrl": ".",
+  "exclude": [
+    "packages/*/dist",
+    "packages/*/test*.js",
+    "packages/*/node_modules",
+    "node_modules",
+    "node_modules/buffer"
+  ],
+  "compileOnSave": false
+}


### PR DESCRIPTION
This pull request does following:

- Adds JSDoc type annotations across the board
- Adds `npm run check` command that runs a type checker.
- Adds type checking phase to the CI
- Adds the `npm run build` and `npm run build:types` scripts that generate `.d.ts` files in `dist`.
- Updates naming / wording to reflect the fact that functions operate on iterables instead of iterators.
- Adds `typesVersions` field to `package.json` so that programs that install these libraries will get types out of the box.
- Fixes the issue that TS uncovered in `it-multipart` (error was swallowed)
- Adds `.npmignore` which doesn't ignore `package/*/dist` directories so they are published with a package.

This also cherry-picks #11 to overcome playwright-test issues