### PR TITLE
fix: use opendir

### DIFF
--- a/packages/it-glob/index.js
+++ b/packages/it-glob/index.js
@@ -50,10 +50,10 @@ async function * glob (dir, pattern, options = {}) {
  * @returns {AsyncIterable<string>}
  */
 async function * _glob (base, dir, pattern, options) {
-  for await (const entry of await fs.readdir(path.join(base, dir))) {
-    const relativeEntryPath = path.join(dir, entry)
-    const absoluteEntryPath = path.join(base, dir, entry)
-    const stats = await fs.stat(absoluteEntryPath)
+  for await (const entry of await fs.opendir(path.join(base, dir))) {
+    const relativeEntryPath = path.join(dir, entry.name)
+    const absoluteEntryPath = path.join(base, dir, entry.name)
+
     let match = minimatch(relativeEntryPath, pattern, options)
 
     if (options.ignore && match && options.ignore.reduce((acc, curr) => {
@@ -62,11 +62,11 @@ async function * _glob (base, dir, pattern, options) {
       match = false
     }
 
-    if (match && !(stats.isDirectory() && options.nodir)) {
+    if (match && !(entry.isDirectory() && options.nodir)) {
       yield options.absolute ? absoluteEntryPath : relativeEntryPath
     }
 
-    if (stats.isDirectory()) {
+    if (entry.isDirectory()) {
       yield * _glob(base, relativeEntryPath, pattern, options)
     }
   }


### PR DESCRIPTION
Replace use of `fs.readdir` with `fs.opendir` as it is much faster
and consumes less memory.

When iterating over a flat directory of `1086421` files with a simple `**/*` pattern
and just counting the number of matches yielded using `it-length`:

Before:

```
counted 1086421
max heap 11.2 MB

real    2m34.757s
user    0m31.694s
sys     0m59.608s
```

After:

```
counted 1086421
max heap 8.17 MB

real    0m6.161s
user    0m4.929s
sys     0m1.583s
```