### PR TITLE
fix: remove ignore option from it-glob

### DIFF
--- a/packages/it-glob/README.md
+++ b/packages/it-glob/README.md
@@ -18,9 +18,6 @@ $ npm install --save it-glob
 const glob = require('it-glob')
 
 const options = {
-  ignore: [
-    'glob' // glob patterns to ignore
-  ],
   cwd // defaults to process.cwd
   absolute // return absolute paths, defaults to false
   nodir // only yield file paths, skip directories
@@ -32,3 +29,5 @@ for await (const path of glob('/path/to/file', '**/*', options)) {
   console.info(path)
 }
 ```
+
+See the [minimatch docs](https://www.npmjs.com/package/minimatch#options) for the full list of options.

--- a/packages/it-glob/index.js
+++ b/packages/it-glob/index.js
@@ -56,17 +56,17 @@ async function * _glob (base, dir, pattern, options) {
 
     let match = minimatch(relativeEntryPath, pattern, options)
 
-    if (options.ignore && match && options.ignore.reduce((acc, curr) => {
-      return acc || minimatch(relativeEntryPath, curr, options)
-    }, false)) {
+    const isDirectory = entry.isDirectory()
+
+    if (isDirectory && options.nodir) {
       match = false
     }
 
-    if (match && !(entry.isDirectory() && options.nodir)) {
+    if (match) {
       yield options.absolute ? absoluteEntryPath : relativeEntryPath
     }
 
-    if (entry.isDirectory()) {
+    if (isDirectory) {
       yield * _glob(base, relativeEntryPath, pattern, options)
     }
   }

--- a/packages/it-glob/test.js
+++ b/packages/it-glob/test.js
@@ -28,23 +28,13 @@ test('it should match files', async t => {
 })
 
 test('it should ignore files', async t => {
-  const files = await all(glob('.', '**/*', {
-    ignore: [
-      '*/index.js',
-      '**/node_modules/**'
-    ]
-  }))
+  const files = await all(glob('.', '**/*!(*/index.js|**/node_modules/**)'))
 
   t.falsy(files.includes('test/index.js'))
 })
 
 test('it should ignore files from absolute directory', async t => {
-  const files = await all(glob(__dirname, '**/*', {
-    ignore: [
-      'test/index.js',
-      '**/node_modules/**'
-    ]
-  }))
+  const files = await all(glob(__dirname, '**/*!(test/index.js|)**/node_modules/**'))
 
   t.falsy(files.includes(path.resolve(__dirname, 'index.js')))
 })
@@ -77,9 +67,10 @@ test('it matches directories', async t => {
 
 test('it skips directories', async t => {
   const files = await all(glob(__dirname, 'node_modules/**/*', {
-    nodir: true
+    nodir: true,
+    dot: true
   }))
 
-  t.falsy(files.includes('node_modules/it-all'))
-  t.truthy(files.includes('node_modules/it-all/package.json'))
+  t.falsy(files.includes('node_modules/.bin'))
+  t.truthy(files.includes('node_modules/.bin/ava'))
 })


### PR DESCRIPTION
Ignores can be specified as part of the glob pattern so the extra `ignore` option is redundant.

BREAKING CHANGE: the ignore option has been removed, specify them in the glob pattern instead