### PR TITLE
feat: add ordered option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,98 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        id: cache
+        env:
+          CACHE_NAME: cache-node-modules
+        with:
+          path: |
+            ~/.npm
+            ./node_modules
+            ./packages/*/node_modules
+            ./packages/*/dist
+          key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+           npm install
+           npm run build
+           npm run link
+
+  check:
+    name: Check
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - uses: actions/cache@v2
+        id: cache
+        env:
+          CACHE_NAME: cache-node-modules
+        with:
+          path: |
+            ~/.npm
+            ./node_modules
+            ./packages/*/node_modules
+            ./packages/*/dist
+          key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          npm install
+          npm run build
+          npm run link
+      - run: |
+          npm run lint
+          npm run dep-check -- -- -- -p
+          npm run dep-check -- -- -- -- --unused
+
+  test-node:
+    name: Unit tests ${{ matrix.project }} node ${{ matrix.node }} ${{ matrix.os }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        node: [16]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - uses: actions/cache@v2
+        id: cache
+        env:
+          CACHE_NAME: cache-node-modules
+        with:
+          path: |
+            ~/.npm
+            ./node_modules
+            ./packages/*/node_modules
+            ./packages/*/dist
+          key: ${{ runner.os }}-build-${{ env.CACHE_NAME }}-${{ github.event.pull_request.head.sha }}
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          npm install
+          npm run build
+          npm run link
+      - run: npm run test -- --since ${{ github.event.pull_request.base.sha }} --concurrency 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
            npm install
-           npm run build
-           npm run link
+           npm run build --if-present
+           npm run link --if-present
 
   check:
     name: Check
@@ -56,12 +56,12 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           npm install
-          npm run build
-          npm run link
+          npm run build --if-present
+          npm run link --if-present
       - run: |
-          npm run lint
-          npm run dep-check -- -- -- -p
-          npm run dep-check -- -- -- -- --unused
+          npm run lint --if-present
+          npm run dep-check --if-present -- -- -- -p
+          npm run dep-check --if-present -- -- -- -- --unused
 
   test-node:
     name: Unit tests ${{ matrix.project }} node ${{ matrix.node }} ${{ matrix.os }}
@@ -93,6 +93,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           npm install
-          npm run build
-          npm run link
+          npm run build --if-present
+          npm run link --if-present
       - run: npm run test -- --since ${{ github.event.pull_request.base.sha }} --concurrency 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-
-node_js:
-  - 'lts/*'
-  - 'node'
-
-script: npm run lint -- --concurrency=1 && npm run check -- --concurrency=1 && npm run coverage -- --concurrency=1
-after_success: coveralls-lerna

--- a/packages/it-parallel/README.md
+++ b/packages/it-parallel/README.md
@@ -1,8 +1,8 @@
 # it-parallel
 
-[![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-parallel-batch)](https://david-dm.org/achingbrain/it?path=packages/it-parallel-batch)
+[![Build status](https://travis-ci.org/achingbrain/it.svg?branch=master)](https://travis-ci.org/achingbrain/it?branch=master) [![Coverage Status](https://coveralls.io/repos/github/achingbrain/it/badge.svg?branch=master)](https://coveralls.io/github/achingbrain/it?branch=master) [![Dependencies Status](https://david-dm.org/achingbrain/it/status.svg?path=packages/it-parallel)](https://david-dm.org/achingbrain/it?path=packages/it-parallel)
 
-> Takes an (async) iterable that emits promise-returning functions, invokes them in parallel up to the concurrency limit and emits the results as they become available but in the same order as the input
+> Takes an (async) iterable that emits promise-returning functions, invokes them in parallel up to the concurrency limit and emits the results as they become available, optionally in the same order as the input
 
 ## Install
 
@@ -42,9 +42,28 @@ const input = [
   }
 ]
 
-const batchSize = 2
+const result = await all(parallel(input, {
+  concurrency: 2
+}))
 
-const result = await all(parallel(input, batchSize))
+// output:
+// start 1
+// start 2
+// end 2
+// start 3
+// end 3
+// end 1
+
+console.info(result) // [2, 3, 1]
+```
+
+If order is important, pass `ordered: true` as an option:
+
+```javascript
+const result = await all(parallel(input, {
+  concurrency: 2,
+  ordered: true
+}))
 
 // output:
 // start 1

--- a/packages/it-parallel/package.json
+++ b/packages/it-parallel/package.json
@@ -1,10 +1,10 @@
 {
   "name": "it-parallel",
   "version": "1.0.0",
-  "description": "Takes an (async) iterable that emits promise-returning functions, invokes them in parallel up to the concurrency limit and emits the results as they become available but in the same order as the input",
+  "description": "Takes an (async) iterable that emits promise-returning functions, invokes them in parallel up to the concurrency limit and emits the results as they become available, optionally in the same order as the input",
   "main": "index.js",
   "repository": "github:achingbrain/it",
-  "homepage": "https://github.com/achingbrain/it#readme",
+  "homepage": "https://github.com/achingbrain/it/tree/master/packages/it-parallel#readme",
   "bugs": "https://github.com/achingbrain/it/issues",
   "scripts": {
     "test": "ava",

--- a/packages/it-parallel/test.js
+++ b/packages/it-parallel/test.js
@@ -13,17 +13,36 @@ const createFn = (ms, result) => {
   }
 }
 
-test('Should execute', async (t) => {
+test('Should execute and return ordered results', async (t) => {
   const input = [
     createFn(1000, 1),
     createFn(2000, 2),
     createFn(100, 3),
-    createFn(100, 4)
+    createFn(500, 4)
   ]
 
-  const res = await all(parallel(input, 3))
+  const res = await all(parallel(input, {
+    concurrency: 3,
+    ordered: true
+  }))
 
   t.deepEqual(res, [1, 2, 3, 4])
+})
+
+test('Should execute and return unordered results', async (t) => {
+  const input = [
+    createFn(1000, 1),
+    createFn(2000, 2),
+    createFn(100, 3),
+    createFn(500, 4)
+  ]
+
+  const res = await all(parallel(input, {
+    concurrency: 3,
+    ordered: false
+  }))
+
+  t.deepEqual(res, [3, 4, 1, 2])
 })
 
 test('Should not exceed concurrency limit', async (t) => {
@@ -55,14 +74,14 @@ test('Should not exceed concurrency limit', async (t) => {
     createFn(10, 5)
   ]
 
-  const res = await all(parallel(input, concurrency))
+  const res = await all(parallel(input, { concurrency, ordered: true }))
 
   t.deepEqual(res, [1, 2, 3, 4, 5])
 
   t.is(runningMax, concurrency)
 })
 
-test('Should propagate errors', async (t) => {
+test('Should propagate task errors', async (t) => {
   const error = new Error('wat')
 
   const input = [
@@ -76,19 +95,92 @@ test('Should propagate errors', async (t) => {
   ]
 
   try {
-    await all(parallel(input, 2))
+    await all(parallel(input, { concurrency: 2 }))
   } catch (err) {
     t.is(err, error)
   }
 })
 
-test('Should work without size parameter', async (t) => {
+test('Should propagate source errors', async (t) => {
+  const error = new Error('Urk!')
+
+  async function * source () {
+    yield async () => 'foo'
+
+    throw error
+  }
+
+  try {
+    await all(parallel(source(), { concurrency: 2 }))
+  } catch (err) {
+    t.is(err, error)
+  }
+})
+
+test('Should allow source to finish if task errors', async (t) => {
+  let sourceFinished = false
+  let index = 0
+  const values = [
+    async () => {
+      await delay(500)
+      throw new Error('Urk!')
+    },
+    async () => {
+      await delay(100)
+      return 'hello'
+    },
+    async () => {
+      await delay(200)
+      return 'hello'
+    },
+    async () => {
+      await delay(300)
+      return 'hello'
+    },
+    async () => {
+      await delay(400)
+      return 'hello'
+    },
+    async () => {
+      await delay(500)
+      return 'world'
+    },
+    async () => {
+      await delay(600)
+      return 'world'
+    }
+  ]
+
+  const source = {
+    [Symbol.asyncIterator]: () => source,
+    async next () {
+      const value = values[index]
+      index++
+
+      return Promise.resolve({
+        done: index === values.length,
+        value
+      })
+    },
+    return () {
+      sourceFinished = true
+    }
+  }
+
+  try {
+    await all(parallel(source, { concurrency: 2, ordered: true }))
+  } catch {
+    t.truthy(sourceFinished)
+  }
+})
+
+test('Should work without concurrency parameter', async (t) => {
   const input = [
     createFn(200, 1),
     createFn(100, 2)
   ]
 
-  const res = await all(parallel(input))
+  const res = await all(parallel(input, { ordered: true }))
 
   t.deepEqual(res, [1, 2])
 })
@@ -98,8 +190,8 @@ test('Should batch up entries with negative batch size', async (t) => {
     createFn(200, 1),
     createFn(100, 2)
   ]
-  const batchSize = -1
-  const res = await all(parallel(input, batchSize))
+  const concurrency = -1
+  const res = await all(parallel(input, { concurrency, ordered: true }))
 
   t.deepEqual(res, [1, 2])
 })
@@ -109,8 +201,8 @@ test('Should batch up entries with zero batch size', async (t) => {
     createFn(200, 1),
     createFn(100, 2)
   ]
-  const batchSize = 0
-  const res = await all(parallel(input, batchSize))
+  const concurrency = 0
+  const res = await all(parallel(input, { concurrency, ordered: true }))
 
   t.deepEqual(res, [1, 2])
 })
@@ -120,8 +212,8 @@ test('Should batch up entries with string batch size', async (t) => {
     createFn(200, 1),
     createFn(100, 2)
   ]
-  const batchSize = '2'
-  const res = await all(parallel(input, batchSize))
+  const concurrency = '2'
+  const res = await all(parallel(input, { concurrency, ordered: true }))
 
   t.deepEqual(res, [1, 2])
 })
@@ -131,8 +223,8 @@ test('Should batch up entries with non-integer batch size', async (t) => {
     createFn(200, 1),
     createFn(100, 2)
   ]
-  const batchSize = 2.5
-  const res = await all(parallel(input, batchSize))
+  const concurrency = 2.5
+  const res = await all(parallel(input, { concurrency, ordered: true }))
 
   t.deepEqual(res, [1, 2])
 })
@@ -150,8 +242,15 @@ test('Should allow returning errors', async (t) => {
       return new Error('derp')
     }
   ]
-  const batchSize = 2
-  const res = await all(parallel(input, batchSize))
+  const concurrency = 2
+  const res = await all(parallel(input, { concurrency, ordered: true }))
 
   t.deepEqual(res, [new Error('herp'), new Error('derp')])
+})
+
+test('Should work with empty source', async (t) => {
+  const input = []
+  const res = await all(parallel(input))
+
+  t.deepEqual(res, [])
 })


### PR DESCRIPTION
Adds an option to return ordered or unordered results, also increases default concurrency because the previous default was 1 (e.g. no concurrency).

```js
for await (const foo of parallel(source, {
    ordered: true, // default: false
    concurrency: 5 // default: Infinity
  })) {
  //...
}
```

BREAKING CHANGE: results are out-of-order by default and default concurrency has increased from 1 to Inifnity