### PR TITLE
fix: accepts iterable also

### DIFF
--- a/packages/it-parallel-batch/index.js
+++ b/packages/it-parallel-batch/index.js
@@ -17,7 +17,7 @@ const batch = require('it-batch')
  * in the same order as the input
  *
  * @template T
- * @param {AsyncIterable<() => Promise<T>>} source
+ * @param {AsyncIterable<() => Promise<T>>|Iterable<() => Promise<T>>} source
  * @param {number} [size=1]
  * @returns {AsyncIterable<T>}
  */


### PR DESCRIPTION
Passed directly to `it-batch` which accepts `Iterable` also: https://github.com/achingbrain/it/blob/master/packages/it-batch/index.js#L8