### PR TITLE
fix!: return iterators from synchronous sources

### DIFF
--- a/packages/it-all/README.md
+++ b/packages/it-all/README.md
@@ -34,10 +34,24 @@ For when you need a one-liner to collect iterable values.
 ```javascript
 import all from 'it-all'
 
-// This can also be an iterator, async iterator, generator, etc
-const values = [0, 1, 2, 3, 4]
+// This can also be an iterator, etc
+const values = function * () {
+  yield * [0, 1, 2, 3, 4]
+}
 
-const arr = await all(values)
+const arr = all(values)
+
+console.info(arr) // 0, 1, 2, 3, 4
+```
+
+Async sources must be awaited:
+
+```javascript
+const values = async function * () {
+  yield * [0, 1, 2, 3, 4]
+}
+
+const arr = await all(values())
 
 console.info(arr) // 0, 1, 2, 3, 4
 ```

--- a/packages/it-all/src/index.ts
+++ b/packages/it-all/src/index.ts
@@ -1,13 +1,32 @@
+function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
+  return thing[Symbol.asyncIterator] != null
+}
 
 /**
  * Collects all values from an (async) iterable and returns them as an array
  */
-export default async function all <T> (source: AsyncIterable<T> | Iterable<T>): Promise<T[]> {
+function all <T> (source: Iterable<T>): T[]
+function all <T> (source: AsyncIterable<T>): Promise<T[]>
+function all <T> (source: AsyncIterable<T> | Iterable<T>): Promise<T[]> | T[] {
+  if (isAsyncIterable(source)) {
+    return (async () => {
+      const arr = []
+
+      for await (const entry of source) {
+        arr.push(entry)
+      }
+
+      return arr
+    })()
+  }
+
   const arr = []
 
-  for await (const entry of source) {
+  for (const entry of source) {
     arr.push(entry)
   }
 
   return arr
 }
+
+export default all

--- a/packages/it-all/test/index.spec.ts
+++ b/packages/it-all/test/index.spec.ts
@@ -4,11 +4,26 @@ import { expect } from 'aegir/chai'
 import all from '../src/index.js'
 
 describe('it-all', () => {
-  it('Should collect all entries of an async iterator as an array', async () => {
+  it('should collect all entries of an iterator as an array', () => {
     const values = [0, 1, 2, 3, 4]
 
-    const res = await all(values)
+    const res = all(values)
 
+    expect(res).to.not.have.property('then')
+    expect(res).to.deep.equal(values)
+  })
+
+  it('should collect all entries of an async iterator as an array', async () => {
+    const values = [0, 1, 2, 3, 4]
+
+    const generator = (async function * (): AsyncGenerator<number, void, undefined> {
+      yield * [0, 1, 2, 3, 4]
+    })()
+
+    const p = all(generator)
+    expect(p).to.have.property('then').that.is.a('function')
+
+    const res = await p
     expect(res).to.deep.equal(values)
   })
 })

--- a/packages/it-batch/README.md
+++ b/packages/it-batch/README.md
@@ -35,11 +35,27 @@ The final batch may be smaller than the max.
 import batch from 'it-batch'
 import all from 'it-all'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [0, 1, 2, 3, 4]
 const batchSize = 2
 
-const result = await all(batch(values, batchSize))
+const result = all(batch(values, batchSize))
+
+console.info(result) // [0, 1], [2, 3], [4]
+```
+
+Async sources must be awaited:
+
+```javascript
+import batch from 'it-batch'
+import all from 'it-all'
+
+const values = async function * () {
+  yield * [0, 1, 2, 3, 4]
+}
+const batchSize = 2
+
+const result = await all(batch(values(), batchSize))
 
 console.info(result) // [0, 1], [2, 3], [4]
 ```

--- a/packages/it-batch/src/index.ts
+++ b/packages/it-batch/src/index.ts
@@ -1,27 +1,73 @@
+function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
+  return thing[Symbol.asyncIterator] != null
+}
+
 /**
  * Takes an (async) iterable that emits things and returns an async iterable that
  * emits those things in fixed-sized batches
  */
-export default async function * batch <T> (source: AsyncIterable<T> | Iterable<T>, size: number = 1): AsyncGenerator<T[], void, undefined> {
-  let things: T[] = []
+function batch <T> (source: Iterable<T>, size?: number): Generator<T[], void, undefined>
+function batch <T> (source: AsyncIterable<T> | Iterable<T>, size?: number): AsyncGenerator<T[], void, undefined>
+function batch <T> (source: AsyncIterable<T> | Iterable<T>, size: number = 1): Generator<T[], void, undefined> | AsyncGenerator<T[], void, undefined> {
+  size = Number(size)
 
-  if (size < 1) {
-    size = 1
+  if (isAsyncIterable(source)) {
+    return (async function * () {
+      let things: T[] = []
+
+      if (size < 1) {
+        size = 1
+      }
+
+      if (size !== Math.round(size)) {
+        throw new Error('Batch size must be an integer')
+      }
+
+      for await (const thing of source) {
+        things.push(thing)
+
+        while (things.length >= size) {
+          yield things.slice(0, size)
+
+          things = things.slice(size)
+        }
+      }
+
+      while (things.length > 0) {
+        yield things.slice(0, size)
+
+        things = things.slice(size)
+      }
+    }())
   }
 
-  for await (const thing of source) {
-    things.push(thing)
+  return (function * () {
+    let things: T[] = []
 
-    while (things.length >= size) {
+    if (size < 1) {
+      size = 1
+    }
+
+    if (size !== Math.round(size)) {
+      throw new Error('Batch size must be an integer')
+    }
+
+    for (const thing of source) {
+      things.push(thing)
+
+      while (things.length >= size) {
+        yield things.slice(0, size)
+
+        things = things.slice(size)
+      }
+    }
+
+    while (things.length > 0) {
       yield things.slice(0, size)
 
       things = things.slice(size)
     }
-  }
-
-  while (things.length > 0) {
-    yield things.slice(0, size)
-
-    things = things.slice(size)
-  }
+  }())
 }
+
+export default batch

--- a/packages/it-batch/test/index.spec.ts
+++ b/packages/it-batch/test/index.spec.ts
@@ -5,51 +5,64 @@ import { expect } from 'aegir/chai'
 import all from 'it-all'
 
 describe('it-batch', () => {
-  it('should batch up entries', async () => {
+  it('should batch up entries', () => {
     const values = [0, 1, 2, 3, 4]
     const batchSize = 2
-    const res = await all(batch(values, batchSize))
+    const gen = batch(values, batchSize)
+    expect(gen[Symbol.iterator]).to.be.ok()
 
+    const res = all(gen)
     expect(res).to.deep.equal([[0, 1], [2, 3], [4]])
   })
 
-  it('should batch up entries without batch size', async () => {
+  it('should batch up async iterator of entries', async () => {
+    const values = async function * (): AsyncGenerator<number, void, undefined> {
+      yield * [0, 1, 2, 3, 4]
+    }
+    const batchSize = 2
+    const gen = batch(values(), batchSize)
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const res = await all(gen)
+    expect(res).to.deep.equal([[0, 1], [2, 3], [4]])
+  })
+
+  it('should batch up entries without batch size', () => {
     const values = [0, 1, 2, 3, 4]
-    const res = await all(batch(values))
+    const res = all(batch(values))
 
     expect(res).to.deep.equal([[0], [1], [2], [3], [4]])
   })
 
-  it('should batch up entries with negative batch size', async () => {
+  it('should batch up entries with negative batch size', () => {
     const values = [0, 1, 2, 3, 4]
     const batchSize = -1
-    const res = await all(batch(values, batchSize))
+    const res = all(batch(values, batchSize))
 
     expect(res).to.deep.equal([[0], [1], [2], [3], [4]])
   })
 
-  it('should batch up entries with zero batch size', async () => {
+  it('should batch up entries with zero batch size', () => {
     const values = [0, 1, 2, 3, 4]
     const batchSize = 0
-    const res = await all(batch(values, batchSize))
+    const res = all(batch(values, batchSize))
 
     expect(res).to.deep.equal([[0], [1], [2], [3], [4]])
   })
 
-  it('should batch up entries with string batch size', async () => {
+  it('should batch up entries with string batch size', () => {
     const values = [0, 1, 2, 3, 4]
     const batchSize = '2'
     // @ts-expect-error batchSize type is incorrect
-    const res = await all(batch(values, batchSize))
+    const res = all(batch(values, batchSize))
 
     expect(res).to.deep.equal([[0, 1], [2, 3], [4]])
   })
 
-  it('should batch up entries with non-integer batch size', async () => {
+  it('should throw when batching up entries with non-integer batch size', () => {
     const values = [0, 1, 2, 3, 4]
     const batchSize = 2.5
-    const res = await all(batch(values, batchSize))
 
-    expect(res).to.deep.equal([[0, 1], [2, 3], [4]])
+    expect(() => all(batch(values, batchSize))).to.throw('Batch size must be an integer')
   })
 })

--- a/packages/it-batched-bytes/README.md
+++ b/packages/it-batched-bytes/README.md
@@ -35,7 +35,7 @@ The final batch may be smaller than the max.
 import batch from 'it-batched-bytes'
 import all from 'it-all'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [
   Uint8Array.from([0]),
   Uint8Array.from([1]),
@@ -43,6 +43,26 @@ const values = [
   Uint8Array.from([3]),
   Uint8Array.from([4])
 ]
+const batchSize = 2
+
+const result = all(batch(values, { size: batchSize }))
+
+console.info(result) // [0, 1], [2, 3], [4]
+```
+
+Async sources must be awaited:
+
+```javascript
+import batch from 'it-batched-bytes'
+import all from 'it-all'
+
+const values = async function * () {
+  yield Uint8Array.from([0])
+  yield Uint8Array.from([1])
+  yield Uint8Array.from([2])
+  yield Uint8Array.from([3])
+  yield Uint8Array.from([4])
+}
 const batchSize = 2
 
 const result = await all(batch(values, { size: batchSize }))

--- a/packages/it-batched-bytes/package.json
+++ b/packages/it-batched-bytes/package.json
@@ -135,7 +135,6 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "it-stream-types": "^1.0.4",
     "p-defer": "^4.0.0",
     "uint8arraylist": "^2.4.1"
   },

--- a/packages/it-batched-bytes/src/index.ts
+++ b/packages/it-batched-bytes/src/index.ts
@@ -1,6 +1,9 @@
 import { Uint8ArrayList } from 'uint8arraylist'
 import defer from 'p-defer'
-import type { Source } from 'it-stream-types'
+
+function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
+  return thing[Symbol.asyncIterator] != null
+}
 
 const DEFAULT_BATCH_SIZE = 1024 * 1024
 const DEFAULT_SERIALIZE = (buf: Uint8Array | Uint8ArrayList, list: Uint8ArrayList): void => { list.append(buf) }
@@ -12,29 +15,18 @@ export interface BatchedBytesOptions {
   size?: number
 
   /**
-   * If this amount of time passes, yield all the bytes in the batch even
-   * if they are below `size` (default: 0 - e.g. on every tick)
-   */
-  yieldAfter?: number
-}
-
-export interface BatchedOptions<T> {
-  /**
-   * The minimum number of bytes that should be in a batch (default: 1MB)
-   */
-  size?: number
-
-  /**
-   * If this amount of time passes, yield all the bytes in the batch even
-   * if they are below `size` (default: 0 - e.g. on every tick)
-   */
-  yieldAfter?: number
-
-  /**
    * If passed, this function should serialize the object and append the
    * result to the passed list
    */
-  serialize: (object: T, list: Uint8ArrayList) => void
+  serialize?: (object: Uint8Array | Uint8ArrayList, list: Uint8ArrayList) => void
+}
+
+export interface AsyncBatchedBytesOptions extends BatchedBytesOptions {
+  /**
+   * If this amount of time passes, yield all the bytes in the batch even
+   * if they are below `size` (default: 0 - e.g. on every tick)
+   */
+  yieldAfter?: number
 }
 
 /**
@@ -42,58 +34,94 @@ export interface BatchedOptions<T> {
  * an internal buffer. Either once the buffer reaches the requested size
  * or the next event loop tick occurs, yield any bytes from the buffer.
  */
-function batchedBytes (source: Source<Uint8Array | Uint8ArrayList>, options?: BatchedBytesOptions): Source<Uint8Array>
-function batchedBytes <T> (source: Source<T>, options: BatchedOptions<T>): Source<Uint8Array>
-async function * batchedBytes (source: Source<any>, options: any = {}): any {
-  let buffer = new Uint8ArrayList()
-  let ended = false
-  let deferred = defer()
+function batchedBytes (source: Iterable<Uint8Array | Uint8ArrayList>, options?: BatchedBytesOptions): Iterable<Uint8Array>
+function batchedBytes (source: AsyncIterable<Uint8Array | Uint8ArrayList>, options?: AsyncBatchedBytesOptions): AsyncIterable<Uint8Array>
+function batchedBytes (source: Iterable<Uint8Array | Uint8ArrayList> | AsyncIterable<Uint8Array | Uint8ArrayList>, options: AsyncBatchedBytesOptions = {}): AsyncIterable<Uint8Array> | Iterable<Uint8Array> {
+  if (isAsyncIterable(source)) {
+    return (async function * () {
+      let buffer = new Uint8ArrayList()
+      let ended = false
+      let deferred = defer()
 
-  let size = Number(options.size ?? DEFAULT_BATCH_SIZE)
+      let size = Number(options.size ?? DEFAULT_BATCH_SIZE)
 
-  if (isNaN(size) || size === 0 || size < 0) {
-    size = DEFAULT_BATCH_SIZE
-  }
-
-  const yieldAfter = options.yieldAfter ?? 0
-  const serialize = options.serialize ?? DEFAULT_SERIALIZE
-
-  void Promise.resolve().then(async () => {
-    try {
-      let timeout
-
-      for await (const buf of source) {
-        serialize(buf, buffer)
-
-        if (buffer.byteLength >= size) {
-          clearTimeout(timeout)
-          deferred.resolve()
-          continue
-        }
-
-        timeout = setTimeout(() => { // eslint-disable-line no-loop-func
-          deferred.resolve()
-        }, yieldAfter)
+      if (isNaN(size) || size === 0 || size < 0) {
+        size = DEFAULT_BATCH_SIZE
       }
 
-      clearTimeout(timeout)
-      deferred.resolve()
-    } catch (err) {
-      deferred.reject(err)
-    } finally {
-      ended = true
-    }
-  })
+      if (size !== Math.round(size)) {
+        throw new Error('Batch size must be an integer')
+      }
 
-  while (!ended) { // eslint-disable-line no-unmodified-loop-condition
-    await deferred.promise
-    deferred = defer()
-    if (buffer.byteLength > 0) {
-      const b = buffer
-      buffer = new Uint8ArrayList()
-      yield b.subarray()
-    }
+      const yieldAfter = options.yieldAfter ?? 0
+      const serialize = options.serialize ?? DEFAULT_SERIALIZE
+
+      void Promise.resolve().then(async () => {
+        try {
+          let timeout
+
+          for await (const buf of source) {
+            serialize(buf, buffer)
+
+            if (buffer.byteLength >= size) {
+              clearTimeout(timeout)
+              deferred.resolve()
+              continue
+            }
+
+            timeout = setTimeout(() => { // eslint-disable-line no-loop-func
+              deferred.resolve()
+            }, yieldAfter)
+          }
+
+          clearTimeout(timeout)
+          deferred.resolve()
+        } catch (err) {
+          deferred.reject(err)
+        } finally {
+          ended = true
+        }
+      })
+
+      while (!ended) { // eslint-disable-line no-unmodified-loop-condition
+        await deferred.promise
+        deferred = defer()
+        if (buffer.byteLength > 0) {
+          const b = buffer
+          buffer = new Uint8ArrayList()
+          yield b.subarray()
+        }
+      }
+    })()
   }
+
+  return (function * () {
+    const buffer = new Uint8ArrayList()
+    let size = Number(options.size ?? DEFAULT_BATCH_SIZE)
+
+    if (isNaN(size) || size === 0 || size < 0) {
+      size = DEFAULT_BATCH_SIZE
+    }
+
+    if (size !== Math.round(size)) {
+      throw new Error('Batch size must be an integer')
+    }
+
+    const serialize = options.serialize ?? DEFAULT_SERIALIZE
+
+    for (const buf of source) {
+      serialize(buf, buffer)
+
+      if (buffer.byteLength >= size) {
+        yield buffer.subarray(0, size)
+        buffer.consume(size)
+      }
+    }
+
+    if (buffer.byteLength > 0) {
+      yield buffer.subarray()
+    }
+  })()
 }
 
 export default batchedBytes

--- a/packages/it-drain/README.md
+++ b/packages/it-drain/README.md
@@ -34,10 +34,22 @@ Mostly useful for tests or when you want to be explicit about consuming an itera
 ```javascript
 import drain from 'it-drain'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [0, 1, 2, 3, 4]
 
-await drain(values)
+drain(values)
+```
+
+Async sources must be awaited:
+
+```javascript
+import drain from 'it-drain'
+
+const values = async function * {
+  yield * [0, 1, 2, 3, 4]
+}
+
+await drain(values())
 ```
 
 ## License

--- a/packages/it-drain/package.json
+++ b/packages/it-drain/package.json
@@ -135,6 +135,7 @@
     "release": "aegir release"
   },
   "devDependencies": {
-    "aegir": "^38.1.7"
+    "aegir": "^38.1.7",
+    "delay": "^5.0.0"
   }
 }

--- a/packages/it-drain/src/index.ts
+++ b/packages/it-drain/src/index.ts
@@ -1,7 +1,21 @@
+function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
+  return thing[Symbol.asyncIterator] != null
+}
+
 /**
  * Drains an (async) iterable discarding its' content and does not return
  * anything
  */
-export default async function drain (source: AsyncIterable<unknown> | Iterable<unknown>): Promise<void> {
-  for await (const _ of source) { } // eslint-disable-line no-unused-vars,no-empty,@typescript-eslint/no-unused-vars
+function drain (source: Iterable<unknown>): void
+function drain (source: AsyncIterable<unknown>): Promise<void>
+function drain (source: AsyncIterable<unknown> | Iterable<unknown>): Promise<void> | void {
+  if (isAsyncIterable(source)) {
+    return (async () => {
+      for await (const _ of source) { } // eslint-disable-line no-unused-vars,no-empty,@typescript-eslint/no-unused-vars
+    })()
+  } else {
+    for (const _ of source) { } // eslint-disable-line no-unused-vars,no-empty,@typescript-eslint/no-unused-vars
+  }
 }
+
+export default drain

--- a/packages/it-drain/test/index.spec.ts
+++ b/packages/it-drain/test/index.spec.ts
@@ -1,8 +1,25 @@
 import { expect } from 'aegir/chai'
+import delay from 'delay'
 import drain from '../src/index.js'
 
 describe('it-drain', () => {
   it('should empty an async iterator', async () => {
+    let done = false
+    const iter = async function * (): AsyncGenerator<number, void, unknown> {
+      yield 1
+      await delay(1)
+      yield 2
+      await delay(1)
+      yield 3
+      done = true
+    }
+
+    await drain(iter())
+
+    expect(done).to.be.true()
+  })
+
+  it('should empty an iterator', () => {
     let done = false
     const iter = function * (): Generator<number, void, unknown> {
       yield 1
@@ -11,7 +28,7 @@ describe('it-drain', () => {
       done = true
     }
 
-    await drain(iter())
+    drain(iter())
 
     expect(done).to.be.true()
   })

--- a/packages/it-first/README.md
+++ b/packages/it-first/README.md
@@ -34,10 +34,24 @@ Mostly useful for tests.
 ```javascript
 import first from 'it-first'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [0, 1, 2, 3, 4]
 
-const res = await first(values)
+const res = first(values)
+
+console.info(res) // 0
+```
+
+Async sources must be awaited:
+
+```javascript
+import first from 'it-first'
+
+const values = async function * () {
+  yield * [0, 1, 2, 3, 4]
+}
+
+const res = await first(values())
 
 console.info(res) // 0
 ```

--- a/packages/it-first/src/index.ts
+++ b/packages/it-first/src/index.ts
@@ -1,12 +1,29 @@
+function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
+  return thing[Symbol.asyncIterator] != null
+}
 
 /**
  * Returns the first result from an (async) iterable, unless empty, in which
  * case returns `undefined`
  */
-export default async function first <T> (source: AsyncIterable<T> | Iterable<T>): Promise<T | undefined> {
-  for await (const entry of source) { // eslint-disable-line no-unreachable-loop
+function first <T> (source: Iterable<T>): T | undefined
+function first <T> (source: AsyncIterable<T>): Promise<T | undefined>
+function first <T> (source: AsyncIterable<T> | Iterable<T>): Promise<T | undefined> | T | undefined {
+  if (isAsyncIterable(source)) {
+    return (async () => {
+      for await (const entry of source) { // eslint-disable-line no-unreachable-loop
+        return entry
+      }
+
+      return undefined
+    })()
+  }
+
+  for (const entry of source) { // eslint-disable-line no-unreachable-loop
     return entry
   }
 
   return undefined
 }
+
+export default first

--- a/packages/it-first/test/index.spec.ts
+++ b/packages/it-first/test/index.spec.ts
@@ -2,11 +2,23 @@ import { expect } from 'aegir/chai'
 import first from '../src/index.js'
 
 describe('it-first', () => {
-  it('should return only the first result from an async iterator', async () => {
+  it('should return only the first result from an iterator', () => {
     const values = [0, 1, 2, 3, 4]
 
-    const res = await first(values)
+    const res = first(values)
 
+    expect(res).to.not.have.property('then')
     expect(res).to.equal(0)
+  })
+
+  it('should return only the first result from an async iterator', async () => {
+    const values = (async function * (): AsyncGenerator<number, void, undefined> {
+      yield * [0, 1, 2, 3, 4]
+    }())
+
+    const res = first(values)
+
+    expect(res).to.have.property('then')
+    await expect(res).to.eventually.equal(0)
   })
 })

--- a/packages/it-last/README.md
+++ b/packages/it-last/README.md
@@ -34,10 +34,24 @@ Mostly useful for tests.
 ```javascript
 import last from 'it-last'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [0, 1, 2, 3, 4]
 
-const res = await last(values)
+const res = last(values)
+
+console.info(res) // 4
+```
+
+Async sources must be awaited:
+
+```javascript
+import last from 'it-last'
+
+const values = async function * () {
+  yield * [0, 1, 2, 3, 4]
+}
+
+const res = await last(values())
 
 console.info(res) // 4
 ```

--- a/packages/it-last/src/index.ts
+++ b/packages/it-last/src/index.ts
@@ -1,13 +1,33 @@
+function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
+  return thing[Symbol.asyncIterator] != null
+}
+
 /**
  * Returns the last item of an (async) iterable, unless empty, in which case
  * return `undefined`
  */
-export default async function last <T> (source: AsyncIterable<T> | Iterable<T>): Promise<T | undefined> {
+function last <T> (source: Iterable<T>): T | undefined
+function last <T> (source: AsyncIterable<T>): Promise<T | undefined>
+function last <T> (source: AsyncIterable<T> | Iterable<T>): Promise<T | undefined> | T | undefined {
+  if (isAsyncIterable(source)) {
+    return (async () => {
+      let res
+
+      for await (const entry of source) {
+        res = entry
+      }
+
+      return res
+    })()
+  }
+
   let res
 
-  for await (const entry of source) {
+  for (const entry of source) {
     res = entry
   }
 
   return res
 }
+
+export default last

--- a/packages/it-last/test/index.spec.ts
+++ b/packages/it-last/test/index.spec.ts
@@ -2,12 +2,24 @@ import { expect } from 'aegir/chai'
 import last from '../src/index.js'
 
 describe('it-last', () => {
-  it('should return only the last result from an async iterator', async () => {
+  it('should return only the last result from an iterator', async () => {
     const values = [0, 1, 2, 3, 4]
 
-    const res = await last(values)
+    const res = last(values)
 
+    expect(res).to.not.have.property('then')
     expect(res).to.equal(4)
+  })
+
+  it('should return only the last result from an async iterator', async () => {
+    const values = (async function * (): AsyncGenerator<number, void, undefined> {
+      yield * [0, 1, 2, 3, 4]
+    }())
+
+    const res = last(values)
+
+    expect(res).to.have.property('then')
+    await expect(res).to.eventually.equal(4)
   })
 
   it('should return undefined if the async iterator was empty', async () => {

--- a/packages/it-length/README.md
+++ b/packages/it-length/README.md
@@ -34,10 +34,24 @@ N.b. will consume the iterable
 ```javascript
 import length from 'it-length'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [0, 1, 2, 3, 4]
 
-const res = await length(values)
+const res = length(values)
+
+console.info(res) // 5
+```
+
+Async sources must be awaited:
+
+```javascript
+import length from 'it-length'
+
+const values = async function * () {
+  yield * [0, 1, 2, 3, 4]
+}
+
+const res = await length(values())
 
 console.info(res) // 5
 ```

--- a/packages/it-length/src/index.ts
+++ b/packages/it-length/src/index.ts
@@ -1,12 +1,32 @@
+function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
+  return thing[Symbol.asyncIterator] != null
+}
+
 /**
  * Consumes the passed iterator and returns the number of items it contained
  */
-export default async function length (iterator: AsyncIterable<unknown> | Iterable<unknown>): Promise<number> {
-  let count = 0
+function length (source: Iterable<unknown>): number
+function length (source: AsyncIterable<unknown>): Promise<number>
+function length (source: AsyncIterable<unknown> | Iterable<unknown>): Promise<number> | number {
+  if (isAsyncIterable(source)) {
+    return (async () => {
+      let count = 0
 
-  for await (const _ of iterator) { // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
-    count++
+      for await (const _ of source) { // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
+        count++
+      }
+
+      return count
+    })()
+  } else {
+    let count = 0
+
+    for (const _ of source) { // eslint-disable-line no-unused-vars,@typescript-eslint/no-unused-vars
+      count++
+    }
+
+    return count
   }
-
-  return count
 }
+
+export default length

--- a/packages/it-length/test/index.spec.ts
+++ b/packages/it-length/test/index.spec.ts
@@ -2,11 +2,23 @@ import { expect } from 'aegir/chai'
 import length from '../src/index.js'
 
 describe('it-length', () => {
-  it('should count the items in an async iterator', async () => {
+  it('should count the items in an iterator', () => {
     const values = [0, 1, 2, 3, 4]
 
-    const res = await length(values)
+    const res = length(values)
 
+    expect(res).to.not.have.property('then')
     expect(res).to.equal(5)
+  })
+
+  it('should count the items in an async iterator', async () => {
+    const values = (async function * (): AsyncGenerator<number, void, undefined> {
+      yield * [0, 1, 2, 3, 4]
+    }())
+
+    const res = length(values)
+
+    expect(res).to.have.property('then')
+    await expect(res).to.eventually.equal(5)
   })
 })

--- a/packages/it-parallel-batch/test/index.spec.ts
+++ b/packages/it-parallel-batch/test/index.spec.ts
@@ -190,23 +190,22 @@ describe('it-parallel-batch', () => {
     expect(res).to.deep.equal([1, 2])
   })
 
-  it('should batch up entries with non-integer batch size', async () => {
-    const input = [
-      async () => {
+  it('should throw when batching up entries with non-integer batch size', async () => {
+    const input = async function * (): AsyncGenerator<() => Promise<number>, void, undefined> {
+      yield async () => {
         await delay(200)
 
         return 1
-      },
-      async () => {
+      }
+      yield async () => {
         await delay(100)
 
         return 2
       }
-    ]
+    }
     const batchSize = 2.5
-    const res = await all(parallelBatch(input, batchSize))
 
-    expect(res).to.deep.equal([1, 2])
+    await expect(all(parallelBatch(input(), batchSize))).to.eventually.be.rejectedWith('Batch size must be an integer')
   })
 
   it('should allow returning errors', async () => {

--- a/packages/it-peekable/README.md
+++ b/packages/it-peekable/README.md
@@ -34,10 +34,31 @@ Lets you look at the contents of an async iterator and decide what to do
 ```javascript
 import peekable from 'it-peekable'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [0, 1, 2, 3, 4]
 
 const it = peekable(value)
+
+const first = it.peek()
+
+console.info(first) // 0
+
+it.push(first)
+
+console.info([...it])
+// [ 0, 1, 2, 3, 4 ]
+```
+
+Async sources must be awaited:
+
+```javascript
+import peekable from 'it-peekable'
+
+const values = async function * () {
+  yield * [0, 1, 2, 3, 4]
+}
+
+const it = peekable(values())
 
 const first = await it.peek()
 
@@ -45,7 +66,7 @@ console.info(first) // 0
 
 it.push(first)
 
-console.info([...it])
+console.info(await all(it))
 // [ 0, 1, 2, 3, 4 ]
 ```
 

--- a/packages/it-peekable/src/index.ts
+++ b/packages/it-peekable/src/index.ts
@@ -15,11 +15,9 @@ type Peekable <T> = Iterable<T> & Peek<T> & Push<T> & Iterator<T>
 
 type AsyncPeekable <T> = AsyncIterable<T> & AsyncPeek<T> & Push<T> & AsyncIterator<T>
 
-export default function peekableIterator <I = Iterable<any> | AsyncIterable<any>> (iterable: I): I extends Iterable<infer T>
-  ? Peekable<T>
-  : I extends AsyncIterable<infer T>
-    ? AsyncPeekable<T>
-    : never {
+function peekable <T> (iterable: Iterable<T>): Peekable<T>
+function peekable <T> (iterable: AsyncIterable<T>): AsyncPeekable<T>
+function peekable <T> (iterable: Iterable<T> | AsyncIterable<T>): Peekable<T> | AsyncPeekable<T> {
   // @ts-expect-error
   const [iterator, symbol] = iterable[Symbol.asyncIterator] != null
     // @ts-expect-error
@@ -52,3 +50,5 @@ export default function peekableIterator <I = Iterable<any> | AsyncIterable<any>
     }
   }
 }
+
+export default peekable

--- a/packages/it-skip/README.md
+++ b/packages/it-skip/README.md
@@ -35,10 +35,25 @@ For when you are only interested in later values from an iterable.
 import take from 'it-skip'
 import all from 'it-all'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [0, 1, 2, 3, 4]
 
-const arr = await all(skip(values, 2))
+const arr = all(skip(values, 2))
+
+console.info(arr) // 2, 3, 4
+```
+
+Async sources must be awaited:
+
+```javascript
+import take from 'it-skip'
+import all from 'it-all'
+
+const values = async function * () {
+  yield * [0, 1, 2, 3, 4]
+}
+
+const arr = await all(skip(values(), 2))
 
 console.info(arr) // 2, 3, 4
 ```

--- a/packages/it-skip/src/index.ts
+++ b/packages/it-skip/src/index.ts
@@ -1,15 +1,38 @@
+function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
+  return thing[Symbol.asyncIterator] != null
+}
 
 /**
  * Skip items from an iterable
  */
-export default async function * skip <T> (source: AsyncIterable<T> | Iterable<T>, offset: number): AsyncGenerator<T, void, undefined> {
-  for await (const entry of source) {
-    if (offset === 0) {
-      yield entry
+function skip <T> (source: Iterable<T>, offset: number): Generator<T, void, undefined>
+function skip <T> (source: AsyncIterable<T>, offset: number): AsyncGenerator<T, void, undefined>
+function skip <T> (source: AsyncIterable<T> | Iterable<T>, offset: number): AsyncGenerator<T, void, undefined> | Generator<T, void, undefined> {
+  if (isAsyncIterable(source)) {
+    return (async function * () {
+      for await (const entry of source) {
+        if (offset === 0) {
+          yield entry
 
-      continue
-    }
+          continue
+        }
 
-    offset--
+        offset--
+      }
+    })()
   }
+
+  return (function * () {
+    for (const entry of source) {
+      if (offset === 0) {
+        yield entry
+
+        continue
+      }
+
+      offset--
+    }
+  })()
 }
+
+export default skip

--- a/packages/it-skip/test/index.spec.ts
+++ b/packages/it-skip/test/index.spec.ts
@@ -6,8 +6,22 @@ describe('it-skip', () => {
   it('should skip values from an iterable', async () => {
     const values = [0, 1, 2, 3, 4]
 
-    const res = await all(skip(values, 2))
+    const gen = skip(values, 2)
+    expect(gen[Symbol.iterator]).to.be.ok()
 
+    const res = all(gen)
+    expect(res).to.deep.equal([2, 3, 4])
+  })
+
+  it('should skip values from an async iterable', async () => {
+    const values = async function * (): AsyncGenerator<number, void, undefined> {
+      yield * [0, 1, 2, 3, 4]
+    }
+
+    const gen = skip(values(), 2)
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const res = await all(gen)
     expect(res).to.deep.equal([2, 3, 4])
   })
 })

--- a/packages/it-sort/README.md
+++ b/packages/it-sort/README.md
@@ -37,8 +37,27 @@ const sorter = (a, b) => {
   return a.localeCompare(b)
 }
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = ['foo', 'bar']
+
+const arr = all(sort(values, sorter))
+
+console.info(arr) // 'bar', 'foo'
+```
+
+Async sources must be awaited:
+
+```javascript
+import sort from 'it-sort'
+import all from 'it-all'
+
+const sorter = (a, b) => {
+  return a.localeCompare(b)
+}
+
+const values = async function * () {
+  yield * ['foo', 'bar']
+}
 
 const arr = await all(sort(values, sorter))
 

--- a/packages/it-sort/test/index.spec.ts
+++ b/packages/it-sort/test/index.spec.ts
@@ -3,14 +3,31 @@ import all from 'it-all'
 import sort, { CompareFunction } from '../src/index.js'
 
 describe('it-sort', () => {
-  it('should sort all entries of an array', async () => {
+  it('should sort all entries of an iterator', () => {
     const values = ['foo', 'bar']
     const sorter: CompareFunction<string> = (a, b) => {
       return a.localeCompare(b)
     }
 
-    const res = await all(sort(values, sorter))
+    const gen = sort(values, sorter)
+    expect(gen[Symbol.iterator]).to.be.ok()
 
+    const res = all(gen)
+    expect(res).to.deep.equal(['bar', 'foo'])
+  })
+
+  it('should sort all entries of an async iterator', async () => {
+    const values = async function * (): AsyncGenerator<string, void, undefined> {
+      yield * ['foo', 'bar']
+    }
+    const sorter: CompareFunction<string> = (a, b) => {
+      return a.localeCompare(b)
+    }
+
+    const gen = sort(values(), sorter)
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const res = await all(gen)
     expect(res).to.deep.equal(['bar', 'foo'])
   })
 })

--- a/packages/it-take/README.md
+++ b/packages/it-take/README.md
@@ -35,10 +35,25 @@ For when you only want a few values out of an iterable.
 import take from 'it-take'
 import all from 'it-all'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [0, 1, 2, 3, 4]
 
-const arr = await all(take(values, 2))
+const arr = all(take(values, 2))
+
+console.info(arr) // 0, 1
+```
+
+Async sources must be awaited:
+
+```javascript
+import take from 'it-take'
+import all from 'it-all'
+
+const values = async function * () {
+  yield * [0, 1, 2, 3, 4]
+}
+
+const arr = await all(take(values(), 2))
 
 console.info(arr) // 0, 1
 ```

--- a/packages/it-take/test/index.spec.ts
+++ b/packages/it-take/test/index.spec.ts
@@ -3,11 +3,25 @@ import all from 'it-all'
 import take from '../src/index.js'
 
 describe('it-take', () => {
-  it('should limit the number of values returned from an iterable', async () => {
+  it('should limit the number of values returned from an iterable', () => {
     const values = [0, 1, 2, 3, 4]
 
-    const res = await all(take(values, 2))
+    const gen = take(values, 2)
+    expect(gen[Symbol.iterator]).to.be.ok()
 
+    const res = all(gen)
+    expect(res).to.deep.equal([0, 1])
+  })
+
+  it('should limit the number of values returned from an async iterable', async () => {
+    const values = async function * (): AsyncGenerator<number, void, undefined> {
+      yield * [0, 1, 2, 3, 4]
+    }
+
+    const gen = take(values(), 2)
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const res = await all(gen)
     expect(res).to.deep.equal([0, 1])
   })
 })

--- a/packages/it-to-buffer/README.md
+++ b/packages/it-to-buffer/README.md
@@ -32,10 +32,25 @@ Loading this module through a script tag will make it's exports available as `It
 ```javascript
 import toBuffer from 'it-to-buffer'
 
-// This can also be an iterator, async iterator, generator, etc
+// This can also be an iterator, generator, etc
 const values = [Buffer.from([0, 1]), Buffer.from([2, 3])]
 
-const result = await toBuffer(values)
+const result = toBuffer(values)
+
+console.info(result) // Buffer[0, 1, 2, 3]
+```
+
+Async sources must be awaited:
+
+```javascript
+import toBuffer from 'it-to-buffer'
+
+const values = async function * () {
+  yield Buffer.from([0, 1])
+  yield Buffer.from([2, 3])
+}
+
+const result = await toBuffer(values())
 
 console.info(result) // Buffer[0, 1, 2, 3]
 ```

--- a/packages/it-to-buffer/src/index.ts
+++ b/packages/it-to-buffer/src/index.ts
@@ -1,15 +1,37 @@
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 
+function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
+  return thing[Symbol.asyncIterator] != null
+}
+
 /**
  * Takes an (async) iterable that yields buffer-like-objects and concats them
  * into one buffer
  */
-export default async function toBuffer (stream: AsyncIterable<Uint8Array> | Iterable<Uint8Array>): Promise<Uint8Array> {
-  let buffer = new Uint8Array(0)
+function toBuffer (source: Iterable<Uint8Array>): Uint8Array
+function toBuffer (source: AsyncIterable<Uint8Array>): Promise<Uint8Array>
+function toBuffer (source: AsyncIterable<Uint8Array> | Iterable<Uint8Array>): Promise<Uint8Array> | Uint8Array {
+  if (isAsyncIterable(source)) {
+    return (async () => {
+      let buffer = new Uint8Array(0)
 
-  for await (const buf of stream) {
-    buffer = uint8ArrayConcat([buffer, buf], buffer.length + buf.length)
+      for await (const buf of source) {
+        buffer = uint8ArrayConcat([buffer, buf], buffer.length + buf.length)
+      }
+
+      return buffer
+    })()
   }
 
-  return buffer
+  const bufs = []
+  let length = 0
+
+  for (const buf of source) {
+    bufs.push(buf)
+    length += buf.byteLength
+  }
+
+  return uint8ArrayConcat(bufs, length)
 }
+
+export default toBuffer

--- a/packages/it-to-buffer/test/index.spec.ts
+++ b/packages/it-to-buffer/test/index.spec.ts
@@ -2,25 +2,40 @@ import { expect } from 'aegir/chai'
 import toBuffer from '../src/index.js'
 
 describe('it-to-buffer', () => {
-  it('should turn a generator that yields buffers into a buffer', async () => {
-    const iter = function * (): Generator<Uint8Array, void, unknown> {
+  it('should turn a generator that yields buffers into a buffer', () => {
+    const iter = function * (): Generator<Uint8Array, void, undefined> {
       yield Uint8Array.from([0])
       yield Uint8Array.from([1])
       yield Uint8Array.from([2])
     }
 
-    const result = await toBuffer(iter())
+    const result = toBuffer(iter())
 
+    expect(result).to.not.have.property('then')
     expect(result).to.equalBytes(Uint8Array.from([0, 1, 2]))
   })
 
-  it('should turn an array buffers into a buffer', async () => {
-    const result = await toBuffer([
+  it('should turn an async generator that yields buffers into a buffer', async () => {
+    const iter = async function * (): AsyncGenerator<Uint8Array, void, undefined> {
+      yield Uint8Array.from([0])
+      yield Uint8Array.from([1])
+      yield Uint8Array.from([2])
+    }
+
+    const result = toBuffer(iter())
+
+    expect(result).to.have.property('then')
+    expect(await result).to.equalBytes(Uint8Array.from([0, 1, 2]))
+  })
+
+  it('should turn an array buffers into a buffer', () => {
+    const result = toBuffer([
       Uint8Array.from([0]),
       Uint8Array.from([1]),
       Uint8Array.from([2])
     ])
 
+    expect(result).to.not.have.property('then')
     expect(result).to.equalBytes(Uint8Array.from([0, 1, 2]))
   })
 })


### PR DESCRIPTION
Crossing async boundaries is not free.  If a synchronous iterator is passed to a function, it should not force the caller to await on the result.

This PR updates some of the basic `it-*` modules to not create unecessary async when they don't have to.

The return types of these functions are now derived from the input types so if you have linting rules that forbid awaiting on non-thenables those awaits will need to be removed.

BREAKING CHANGE: if you pass a synchronous iterator to a function it will return a synchronous generator in response