### PR TITLE
fix: fix it-to-browser-readablestream-types

### DIFF
--- a/packages/it-to-browser-readablestream/src/index.ts
+++ b/packages/it-to-browser-readablestream/src/index.ts
@@ -8,8 +8,8 @@ type Source<T> = SourceExt & UnderlyingSource<T>
 /**
  * Converts an (async) iterator into a WHATWG ReadableStream
  */
-export default function itToBrowserReadableStream <T extends ArrayBufferView > (source: AsyncIterator<T> | Iterator<T>, queuingStrategy: QueuingStrategy<T> = {}): ReadableStream<T> {
-  const s: Source<T> = {
+export default function itToBrowserReadableStream <T extends ArrayBufferView> (source: AsyncIterator<T> | Iterator<T>, queuingStrategy: QueuingStrategy<T> = {}): ReadableStream<T> {
+  const s: Source<ArrayBufferView> = {
     _cancelled: false,
 
     async start () {


### PR DESCRIPTION
A typescript patch update has broken the types