### PR TITLE
fix: allow object streams in it-batched-bytes

### DIFF
--- a/packages/it-batched-bytes/src/index.ts
+++ b/packages/it-batched-bytes/src/index.ts
@@ -44,7 +44,7 @@ function batchedBytes (source: Iterable<Uint8Array | Uint8ArrayList>, options?: 
 function batchedBytes (source: Iterable<Uint8Array | Uint8ArrayList> | AsyncIterable<Uint8Array | Uint8ArrayList>, options?: AsyncBatchedBytesOptions): AsyncIterable<Uint8Array>
 function batchedBytes <T> (source: Iterable<T>, options?: BatchedObjectsOptions<T>): Iterable<Uint8Array>
 function batchedBytes <T> (source: Iterable<T> | AsyncIterable<T>, options?: AsyncBatchedObjectsOptions<T>): AsyncIterable<Uint8Array>
-function batchedBytes <T = Uint8Array | Uint8ArrayList> (source: Iterable<T> | AsyncIterable<T>, options?: AsyncBatchedObjectsOptions<T>): AsyncIterable<Uint8Array> | Iterable<Uint8Array> {
+function batchedBytes <T = Uint8Array | Uint8ArrayList> (source: Iterable<T> | AsyncIterable<T>, options?: Partial<AsyncBatchedObjectsOptions<T>>): AsyncIterable<Uint8Array> | Iterable<Uint8Array> {
   if (isAsyncIterable(source)) {
     return (async function * () {
       let buffer = new Uint8ArrayList()

--- a/packages/it-batched-bytes/test/index.spec.ts
+++ b/packages/it-batched-bytes/test/index.spec.ts
@@ -106,23 +106,6 @@ describe('it-batched-bytes', () => {
     expect(() => all(batch(values, { size: batchSize }))).to.throw('Batch size must be an integer')
   })
 
-  it('should batch up values that need serializing', () => {
-    const values = [
-      Uint8Array.of(0),
-      Uint8Array.of(1),
-      Uint8Array.of(2),
-      Uint8Array.of(3),
-      Uint8Array.of(4)
-    ]
-    const batchSize = 3
-    const res = all(batch(values, {
-      size: batchSize,
-      serialize: (obj, list) => { list.append(obj) }
-    }))
-
-    expect(res).to.deep.equal([Uint8Array.of(0, 1, 2), Uint8Array.of(3, 4)])
-  })
-
   it('should accept objects as values and allow serializing them', () => {
     const values = [
       { bytes: Uint8Array.of(0) },


### PR DESCRIPTION
The objects must be turned into bytes by supplying a `serialize` optional function.