### PR TITLE
feat: add `writeV` method to pb and lp streams to batch write

### DIFF
--- a/packages/it-length-prefixed-stream/benchmark/stream.js
+++ b/packages/it-length-prefixed-stream/benchmark/stream.js
@@ -1,0 +1,38 @@
+import { duplexPair } from 'it-pair/duplex'
+import { lpStream } from '../dist/src/index.js'
+
+const DATA_LENGTH = 1024 * 1024 * 1024
+const CHUNK_SIZE = 256 * 1024
+const ITERATIONS = 10
+
+const results = []
+
+for (let i = 0; i < ITERATIONS; i++) {
+  const duplex = duplexPair()
+  const inputStream = lpStream(duplex[0])
+  const outputStream = lpStream(duplex[1])
+  let read = 0
+
+  const start = Date.now()
+
+  while (read < DATA_LENGTH) {
+    const bufs = new Array(5).fill(0).map(() => new Uint8Array(CHUNK_SIZE))
+
+    await inputStream.writeV(
+      bufs
+    )
+
+    const buf = await outputStream.read()
+
+    read += buf.byteLength
+  }
+
+  const finish = Date.now() - start
+  results.push(finish)
+}
+
+const megs = DATA_LENGTH / (1024 * 1024)
+const secs = (results.reduce((acc, curr) => acc + curr, 0) / results.length) / 1000
+
+// eslint-disable-next-line no-console
+console.info((megs / secs).toFixed(2), 'MB/s')

--- a/packages/it-length-prefixed-stream/src/index.ts
+++ b/packages/it-length-prefixed-stream/src/index.ts
@@ -50,6 +50,11 @@ export interface LengthPrefixedStream <Stream = unknown> {
   write: (input: Uint8Array | Uint8ArrayList, options?: AbortOptions) => Promise<void>
 
   /**
+   * Write passed list of bytes, prefix by their individual lengths to the stream as a single write
+   */
+  writeV: (input: Array<Uint8Array | Uint8ArrayList>, options?: AbortOptions) => Promise<void>
+
+  /**
    * Returns the underlying stream
    */
   unwrap: () => Stream
@@ -111,6 +116,14 @@ export function lpStream <Stream extends Duplex<any, any, any>> (duplex: Stream,
     write: async (data, options?: AbortOptions) => {
       // encode, write
       await bytes.write(lp.encode.single(data, opts), options)
+    },
+    writeV: async (data, options?: AbortOptions) => {
+      const list = new Uint8ArrayList(
+        ...data.map(buf => lp.encode.single(buf, opts))
+      )
+
+      // encode, write
+      await bytes.write(list, options)
     },
     unwrap: () => {
       return bytes.unwrap()

--- a/packages/it-length-prefixed-stream/test/index.spec.ts
+++ b/packages/it-length-prefixed-stream/test/index.spec.ts
@@ -166,5 +166,20 @@ Object.keys(tests).forEach(key => {
       const res = await lp.read()
       expect(res.subarray()).to.equalBytes(data.subarray())
     })
+
+    it('lp writeV', async () => {
+      const data = test.from('hellllllllloooo')
+      const input = new Uint8ArrayList(data, data, data)
+
+      const p = lp.writeV([data, data, data])
+      const res = new Uint8ArrayList(
+        await lp.read(),
+        await lp.read(),
+        await lp.read()
+      )
+      expect(res.subarray()).to.equalBytes(input.subarray())
+
+      await expect(p).to.eventually.be.undefined()
+    })
   })
 })

--- a/packages/it-protobuf-stream/src/index.ts
+++ b/packages/it-protobuf-stream/src/index.ts
@@ -65,7 +65,7 @@ export interface ProtobufStream <Stream = unknown> {
   /**
    * Encode the passed objects as protobuf messages and write their length-prefixed bytes to the stream as a single write
    */
-  writeV: <T>(input: Array<T>, proto: { encode: Encoder<T> }, options?: AbortOptions) => Promise<void>
+  writeV: <T>(input: T[], proto: { encode: Encoder<T> }, options?: AbortOptions) => Promise<void>
 
   /**
    * Returns an object with read/write methods for operating on one specific type of protobuf message

--- a/packages/it-protobuf-stream/src/index.ts
+++ b/packages/it-protobuf-stream/src/index.ts
@@ -58,9 +58,14 @@ export interface ProtobufStream <Stream = unknown> {
   read: <T>(proto: { decode: Decoder<T> }, options?: AbortOptions) => Promise<T>
 
   /**
-   * Encode the passed object as a protobuf message and write it's length-prefixed bytes tot he stream
+   * Encode the passed object as a protobuf message and write it's length-prefixed bytes to the stream
    */
   write: <T>(data: T, proto: { encode: Encoder<T> }, options?: AbortOptions) => Promise<void>
+
+  /**
+   * Encode the passed objects as protobuf messages and write their length-prefixed bytes to the stream as a single write
+   */
+  writeV: <T>(input: Array<T>, proto: { encode: Encoder<T> }, options?: AbortOptions) => Promise<void>
 
   /**
    * Returns an object with read/write methods for operating on one specific type of protobuf message
@@ -88,6 +93,11 @@ export interface MessageStream <T, S = unknown> {
   write: (d: T, options?: AbortOptions) => Promise<void>
 
   /**
+   * Write several messages to the stream
+   */
+  writeV: (d: T[], options?: AbortOptions) => Promise<void>
+
+  /**
    * Unwrap the underlying protobuf stream
    */
   unwrap: () => ProtobufStream<S>
@@ -107,14 +117,19 @@ export function pbStream <Stream extends Duplex<any, any, any>> (duplex: Stream,
 
       return proto.decode(value)
     },
-    write: async (data, proto, options?: AbortOptions) => {
+    write: async (message, proto, options?: AbortOptions) => {
       // encode, writeLP
-      await lp.write(proto.encode(data), options)
+      await lp.write(proto.encode(message), options)
+    },
+    writeV: async (messages, proto, options?: AbortOptions) => {
+      // encode, writeLP
+      await lp.writeV(messages.map(message => proto.encode(message)), options)
     },
     pb: (proto) => {
       return {
         read: async (options) => W.read(proto, options),
         write: async (d, options) => W.write(d, proto, options),
+        writeV: async (d, options) => W.writeV(d, proto, options),
         unwrap: () => W
       }
     },


### PR DESCRIPTION
Adds `writeV` methods that allow us to write a number of messages or length-prefixed buffers in one go.