### PR TITLE
fix: only overwrite source if readbuffer has bytes

### DIFF
--- a/packages/it-byte-stream/src/index.ts
+++ b/packages/it-byte-stream/src/index.ts
@@ -152,11 +152,13 @@ export function byteStream <Stream extends Duplex<any, any, any>> (duplex: Strea
       }
     },
     unwrap: () => {
-      const originalStream = duplex.source
-      duplex.source = (async function * () {
-        yield * readBuffer
-        yield * originalStream
-      }())
+      if (readBuffer.byteLength > 0) {
+        const originalStream = duplex.source
+        duplex.source = (async function * () {
+          yield * readBuffer
+          yield * originalStream
+        }())
+      }
 
       return duplex
     }


### PR DESCRIPTION
There is no need to overwrite the source property of the passed duplex if the readbuffer is empty.