### PR TITLE
fix: await initial pushable read

### DIFF
--- a/packages/it-byte-stream/src/pushable.ts
+++ b/packages/it-byte-stream/src/pushable.ts
@@ -27,8 +27,6 @@ class QueuelessPushable <T> implements Pushable<T> {
     this.ended = false
 
     this.needNext = deferred()
-    this.needNext.resolve()
-
     this.haveNext = deferred()
   }
 


### PR DESCRIPTION
Without this the first write to a byte/length-prefixed or protobuf stream doesn't wait for the message to be read.