### PR TITLE
fix: simplify lp stream read/write

### DIFF
--- a/packages/it-length-prefixed-stream/package.json
+++ b/packages/it-length-prefixed-stream/package.json
@@ -133,7 +133,6 @@
   },
   "dependencies": {
     "it-byte-stream": "^1.0.0",
-    "it-length-prefixed": "^9.0.1",
     "it-stream-types": "^2.0.1",
     "uint8-varint": "^2.0.1",
     "uint8arraylist": "^2.4.1"

--- a/packages/it-length-prefixed-stream/test/fixtures/int32BE-decode.ts
+++ b/packages/it-length-prefixed-stream/test/fixtures/int32BE-decode.ts
@@ -1,10 +1,9 @@
-import type { LengthDecoderFunction } from 'it-length-prefixed'
+import type { Uint8ArrayList } from 'uint8arraylist'
 
-export const int32BEDecode: LengthDecoderFunction = (data) => {
+export function int32BEDecode (data: Uint8ArrayList): number {
   if (data.length < 4) {
     throw RangeError('Could not decode int32BE')
   }
 
   return data.getInt32(0, false)
 }
-int32BEDecode.bytes = 4 // Always because fixed length

--- a/packages/it-length-prefixed-stream/test/fixtures/int32BE-encode.ts
+++ b/packages/it-length-prefixed-stream/test/fixtures/int32BE-encode.ts
@@ -1,7 +1,6 @@
 import { Uint8ArrayList } from 'uint8arraylist'
-import type { LengthEncoderFunction } from 'it-length-prefixed'
 
-export const int32BEEncode: LengthEncoderFunction = (value) => {
+export function int32BEEncode (value: number): Uint8ArrayList {
   const data = new Uint8ArrayList(
     new Uint8Array(4)
   )
@@ -9,4 +8,3 @@ export const int32BEEncode: LengthEncoderFunction = (value) => {
 
   return data
 }
-int32BEEncode.bytes = 4 // Always because fixed length

--- a/packages/it-length-prefixed-stream/test/index.spec.ts
+++ b/packages/it-length-prefixed-stream/test/index.spec.ts
@@ -113,7 +113,7 @@ Object.keys(tests).forEach(key => {
       const bytes = byteStream(lp.unwrap())
       const res = await bytes.read()
 
-      const length = test.allocUnsafe(int32BEEncode.bytes)
+      const length = test.allocUnsafe(4)
       test.writeInt32BE(length, data.length, 0)
       const expected = test.concat([length, data])
       expect(res.subarray()).to.equalBytes(expected.subarray())
@@ -125,7 +125,7 @@ Object.keys(tests).forEach(key => {
       // write raw lp-prefixed bytes
       const bytes = byteStream(duplex)
       const data = test.from('hellllllllloooo')
-      const length = test.allocUnsafe(int32BEDecode.bytes)
+      const length = test.allocUnsafe(4)
       test.writeInt32BE(length, data.length, 0)
       const encoded = test.concat([length, data])
       void bytes.write(encoded)


### PR DESCRIPTION
Remove usage of `it-length-prefixed` library, which was used for types and encoding logic.

- the length encoder / decoder types are now inlined (and simpler) (and backwards compatible)
- pull `decodeLength` into the body of the lp stream closure (only instantiated once, instead of on each `read`)
- manually encode the length prefix in `write` and `writeV` (this saves unnecessary function calls and allocations)