### PR TITLE
fix: add read/write tests for it-byte-stream

### DIFF
--- a/packages/it-byte-stream/package.json
+++ b/packages/it-byte-stream/package.json
@@ -139,6 +139,7 @@
   },
   "devDependencies": {
     "aegir": "^41.1.9",
+    "delay": "^6.0.0",
     "it-pair": "^2.0.2",
     "uint8arrays": "^5.0.0"
   }


### PR DESCRIPTION
To prevent regresssions and ensure the contract is respected.