### PR TITLE
feat: pass index to callback functions

### DIFF
--- a/packages/it-filter/test/index.spec.ts
+++ b/packages/it-filter/test/index.spec.ts
@@ -2,12 +2,12 @@ import { expect } from 'aegir/chai'
 import all from 'it-all'
 import filter from '../src/index.js'
 
-function * values (): Generator<number, void, undefined> {
-  yield * [0, 1, 2, 3, 4]
+function * values (vals: number[] = [0, 1, 2, 3, 4]): Generator<number, void, undefined> {
+  yield * vals
 }
 
-async function * asyncValues (): AsyncGenerator<number, void, undefined> {
-  yield * values()
+async function * asyncValues (vals: number[] = [0, 1, 2, 3, 4]): AsyncGenerator<number, void, undefined> {
+  yield * values(vals)
 }
 
 describe('it-filter', () => {
@@ -51,5 +51,43 @@ describe('it-filter', () => {
 
     expect(res[Symbol.asyncIterator]).to.be.ok()
     await expect(all(res)).to.eventually.deep.equal([3, 4])
+  })
+
+  it('should filter values with indexes', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const callbackArgs: any[] = []
+    const gen = filter(values(vals), (...args: any[]) => {
+      callbackArgs.push(args)
+      return true
+    })
+    expect(gen[Symbol.iterator]).to.be.ok()
+
+    const results = all(gen)
+    expect(results).to.have.lengthOf(vals.length)
+    expect(callbackArgs).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(callbackArgs).to.have.nested.property(`[${index}][0]`, value)
+      expect(callbackArgs).to.have.nested.property(`[${index}][1]`, index)
+    })
+  })
+
+  it('should filter async values with indexes', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const callbackArgs: any[] = []
+    const gen = filter(asyncValues(vals), (...args: any[]) => {
+      callbackArgs.push(args)
+      return true
+    })
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const results = await all(gen)
+    expect(results).to.have.lengthOf(vals.length)
+    expect(callbackArgs).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(callbackArgs).to.have.nested.property(`[${index}][0]`, value)
+      expect(callbackArgs).to.have.nested.property(`[${index}][1]`, index)
+    })
   })
 })

--- a/packages/it-foreach/test/index.spec.ts
+++ b/packages/it-foreach/test/index.spec.ts
@@ -2,12 +2,20 @@ import { expect } from 'aegir/chai'
 import all from 'it-all'
 import forEach from '../src/index.js'
 
+function * values (vals: number[] = [0, 1, 2, 3, 4]): Generator<number, void, undefined> {
+  yield * vals
+}
+
+async function * asyncValues (vals: number[] = [0, 1, 2, 3, 4]): AsyncGenerator<number, void, undefined> {
+  yield * values(vals)
+}
+
 describe('it-for-each', () => {
   it('should iterate over every value', () => {
-    const values = [0, 1, 2, 3, 4]
+    const vals = [0, 1, 2, 3, 4]
     let sum = 0
 
-    const gen = forEach(values, (val) => {
+    const gen = forEach(values(vals), (val) => {
       sum += val
     })
 
@@ -15,17 +23,15 @@ describe('it-for-each', () => {
 
     const res = all(gen)
 
-    expect(res).to.deep.equal(values)
+    expect(res).to.deep.equal(vals)
     expect(10).to.equal(sum)
   })
 
   it('should iterate over every async value', async () => {
-    const values = async function * (): AsyncGenerator<number, void, undefined> {
-      yield * [0, 1, 2, 3, 4]
-    }
+    const vals = [0, 1, 2, 3, 4]
     let sum = 0
 
-    const gen = forEach(values(), (val) => {
+    const gen = forEach(asyncValues(vals), (val) => {
       sum += val
     })
 
@@ -33,30 +39,12 @@ describe('it-for-each', () => {
 
     const res = await all(gen)
 
-    expect(res).to.deep.equal(await all(values()))
+    expect(res).to.deep.equal(vals)
     expect(10).to.equal(sum)
   })
 
   it('should iterate over every value asyncly', async () => {
-    const values = [0, 1, 2, 3, 4]
-    let sum = 0
-
-    const gen = forEach(values, async (val) => {
-      sum += val
-    })
-
-    expect(gen[Symbol.asyncIterator]).to.be.ok()
-
-    const res = await all(gen)
-
-    expect(res).to.deep.equal(values)
-    expect(10).to.equal(sum)
-  })
-
-  it('should iterate over every async value asyncly', async () => {
-    const values = async function * (): AsyncGenerator<number, void, undefined> {
-      yield * [0, 1, 2, 3, 4]
-    }
+    const vals = [0, 1, 2, 3, 4]
     let sum = 0
 
     const gen = forEach(values(), async (val) => {
@@ -67,17 +55,32 @@ describe('it-for-each', () => {
 
     const res = await all(gen)
 
-    expect(res).to.deep.equal(await all(values()))
+    expect(res).to.deep.equal(vals)
+    expect(10).to.equal(sum)
+  })
+
+  it('should iterate over every async value asyncly', async () => {
+    const vals = [0, 1, 2, 3, 4]
+    let sum = 0
+
+    const gen = forEach(asyncValues(), async (val) => {
+      sum += val
+    })
+
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const res = await all(gen)
+
+    expect(res).to.deep.equal(vals)
     expect(10).to.equal(sum)
   })
 
   it('should abort source', () => {
-    const values = [0, 1, 2, 3, 4]
     let sum = 0
     const err = new Error('wat')
 
     try {
-      all(forEach(values, (val) => {
+      all(forEach(values(), (val) => {
         sum += val
 
         if (val === 3) {
@@ -90,5 +93,59 @@ describe('it-for-each', () => {
       expect(e).to.equal(err)
       expect(sum).to.equal(6)
     }
+  })
+
+  it('should iterate over values with indexes', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const callbackArgs: any[] = []
+    const gen = forEach(values(vals), (...args: [number]) => {
+      callbackArgs.push(args)
+    })
+    expect(gen[Symbol.iterator]).to.be.ok()
+
+    const results = all(gen)
+    expect(results).to.have.lengthOf(vals.length)
+    expect(callbackArgs).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(callbackArgs).to.have.nested.property(`[${index}][0]`, value)
+      expect(callbackArgs).to.have.nested.property(`[${index}][1]`, index)
+    })
+  })
+
+  it('should iterate over async values with indexes', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const callbackArgs: any[] = []
+    const gen = forEach(asyncValues(vals), (...args: any[]) => {
+      callbackArgs.push(args)
+    })
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const results = await all(gen)
+    expect(results).to.have.lengthOf(vals.length)
+    expect(callbackArgs).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(callbackArgs).to.have.nested.property(`[${index}][0]`, value)
+      expect(callbackArgs).to.have.nested.property(`[${index}][1]`, index)
+    })
+  })
+
+  it('should iterate over async values with indexes asyncly', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const callbackArgs: any[] = []
+    const gen = forEach(asyncValues(vals), async (...args: any[]) => {
+      callbackArgs.push(args)
+    })
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const results = await all(gen)
+    expect(results).to.have.lengthOf(vals.length)
+    expect(callbackArgs).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(callbackArgs).to.have.nested.property(`[${index}][0]`, value)
+      expect(callbackArgs).to.have.nested.property(`[${index}][1]`, index)
+    })
   })
 })

--- a/packages/it-map/test/index.spec.ts
+++ b/packages/it-map/test/index.spec.ts
@@ -2,20 +2,20 @@ import { expect } from 'aegir/chai'
 import all from 'it-all'
 import map from '../src/index.js'
 
-async function * asyncGenerator (): AsyncGenerator<number> {
-  yield 1
+async function * asyncGenerator (vals: number[] = [1]): AsyncGenerator<number, void, undefined> {
+  yield * vals
 }
 
-function * generator (): Generator<number> {
-  yield 1
+function * generator (vals: number[] = [1]): Generator<number, void, undefined> {
+  yield * vals
 }
 
-async function * source (): Generator<number> | AsyncGenerator<number> {
-  yield 1
+async function * source (vals: number[] = [1]): Generator<number, void, undefined> | AsyncGenerator<number, void, undefined> {
+  yield * vals
 }
 
 describe('it-map', () => {
-  it('should map an async iterator', async () => {
+  it('should map an async generator', async () => {
     const gen = map(asyncGenerator(), (val) => val + 1)
     expect(gen[Symbol.asyncIterator]).to.be.ok()
 
@@ -24,7 +24,21 @@ describe('it-map', () => {
     expect(results).to.have.nested.property('[0]', 2)
   })
 
-  it('should map an async iterator to a promise', async () => {
+  it('should map an async generator with indexes', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const gen = map(asyncGenerator(vals), (...args: any[]) => args)
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const results = await all(gen)
+    expect(results).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(results).to.have.nested.property(`[${index}][0]`, value)
+      expect(results).to.have.nested.property(`[${index}][1]`, index)
+    })
+  })
+
+  it('should map an async generator to a promise', async () => {
     const gen = map(asyncGenerator(), async (val) => val + 1)
     expect(gen[Symbol.asyncIterator]).to.be.ok()
 
@@ -40,6 +54,20 @@ describe('it-map', () => {
     const results = all(gen)
     expect(results).to.have.lengthOf(1)
     expect(results).to.have.nested.property('[0]', 2)
+  })
+
+  it('should map an iterator with indexes', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const gen = map(generator(vals), (...args: any[]) => args)
+    expect(gen[Symbol.iterator]).to.be.ok()
+
+    const results = all(gen)
+    expect(results).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(results).to.have.nested.property(`[${index}][0]`, value)
+      expect(results).to.have.nested.property(`[${index}][1]`, index)
+    })
   })
 
   it('should map an iterator to a promise', async () => {
@@ -58,5 +86,19 @@ describe('it-map', () => {
     const results = await all(gen)
     expect(results).to.have.lengthOf(1)
     expect(results).to.have.nested.property('[0]', 2)
+  })
+
+  it('should map a source with indexes', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const gen = map(source(vals), (...args: any[]) => args)
+    expect(gen[Symbol.asyncIterator]).to.be.ok()
+
+    const results = await all(gen)
+    expect(results).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(results).to.have.nested.property(`[${index}][0]`, value)
+      expect(results).to.have.nested.property(`[${index}][1]`, index)
+    })
   })
 })

--- a/packages/it-reduce/src/index.ts
+++ b/packages/it-reduce/src/index.ts
@@ -11,7 +11,7 @@
  * // This can also be an iterator, generator, etc
  * const values = [0, 1, 2, 3, 4]
  *
- * const result = reduce(values, (acc, curr) => acc + curr, 0)
+ * const result = reduce(values, (acc, curr, index) => acc + curr, 0)
  *
  * console.info(result) // 10
  * ```
@@ -25,7 +25,7 @@
  *   yield * [0, 1, 2, 3, 4]
  * }
  *
- * const result = await reduce(values(), (acc, curr) => acc + curr, 0)
+ * const result = await reduce(values(), (acc, curr, index) => acc + curr, 0)
  *
  * console.info(result) // 10
  * ```
@@ -38,13 +38,15 @@ function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
 /**
  * Reduces the values yielded by an (async) iterable
  */
-function reduce <T, V> (source: Iterable<T>, func: (acc: V, curr: T) => V, init: V): V
-function reduce <T, V> (source: Iterable<T> | AsyncIterable<T>, func: (acc: V, curr: T) => V, init: V): Promise<V>
-function reduce <T, V> (source: Iterable<T> | AsyncIterable<T>, func: (acc: V, curr: T) => V, init: V): Promise<V> | V {
+function reduce <T, V> (source: Iterable<T>, func: (acc: V, curr: T, index: number) => V, init: V): V
+function reduce <T, V> (source: Iterable<T> | AsyncIterable<T>, func: (acc: V, curr: T, index: number) => V, init: V): Promise<V>
+function reduce <T, V> (source: Iterable<T> | AsyncIterable<T>, func: (acc: V, curr: T, index: number) => V, init: V): Promise<V> | V {
+  let index = 0
+
   if (isAsyncIterable(source)) {
     return (async function () {
       for await (const val of source) {
-        init = func(init, val)
+        init = func(init, val, index++)
       }
 
       return init
@@ -52,7 +54,7 @@ function reduce <T, V> (source: Iterable<T> | AsyncIterable<T>, func: (acc: V, c
   }
 
   for (const val of source) {
-    init = func(init, val)
+    init = func(init, val, index++)
   }
 
   return init

--- a/packages/it-reduce/test/index.spec.ts
+++ b/packages/it-reduce/test/index.spec.ts
@@ -1,29 +1,59 @@
 import { expect } from 'aegir/chai'
 import reduce from '../src/index.js'
 
+function * values (vals: number[] = [0, 1, 2, 3, 4]): Generator<number, void, undefined> {
+  yield * vals
+}
+
+async function * asyncValues (vals: number[] = [0, 1, 2, 3, 4]): AsyncGenerator<number, void, undefined> {
+  yield * values(vals)
+}
+
 describe('it-reduce', () => {
   it('should reduce the values yielded from an iterator', () => {
-    const iter = function * (): Generator<number, void, unknown> {
-      yield 1
-      yield 2
-      yield 3
-    }
+    const result = reduce(values(), (acc, curr) => acc + curr, 0)
 
-    const result = reduce(iter(), (acc, curr) => acc + curr, 0)
-
-    expect(result).to.equal(6)
+    expect(result).to.equal(10)
   })
 
   it('should reduce the values yielded from an async iterator', async () => {
-    const iter = async function * (): AsyncGenerator<number, void, unknown> {
-      yield 1
-      yield 2
-      yield 3
-    }
-
-    const result = reduce(iter(), (acc, curr) => acc + curr, 0)
+    const result = reduce(asyncValues(), (acc, curr) => acc + curr, 0)
 
     expect(result).to.have.property('then').that.is.a('function')
-    await expect(result).to.eventually.equal(6)
+    await expect(result).to.eventually.equal(10)
+  })
+
+  it('should reduce the values yielded from an iterator with indexes', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const callbackArgs: any[] = []
+    const result = reduce(values(vals), (...args: any[]) => {
+      callbackArgs.push(args)
+      return 0
+    }, 0)
+
+    expect(result).to.equal(0)
+    expect(callbackArgs).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(callbackArgs).to.have.nested.property(`[${index}][1]`, value)
+      expect(callbackArgs).to.have.nested.property(`[${index}][2]`, index)
+    })
+  })
+
+  it('should reduce the values yielded from an async iterator with indexes', async () => {
+    const vals = [4, 3, 2, 1, 0]
+    const callbackArgs: any[] = []
+    const result = await reduce(asyncValues(vals), (...args: any[]) => {
+      callbackArgs.push(args)
+      return 0
+    }, 0)
+
+    expect(result).to.equal(0)
+    expect(callbackArgs).to.have.lengthOf(vals.length)
+
+    vals.forEach((value, index) => {
+      expect(callbackArgs).to.have.nested.property(`[${index}][1]`, value)
+      expect(callbackArgs).to.have.nested.property(`[${index}][2]`, index)
+    })
   })
 })


### PR DESCRIPTION
Pass the current index to filter/foreach/map and reduce functions similar to Array.prototype functions.