### PR TITLE
fix: accept iterable, convert to iterator internally

### DIFF
--- a/packages/it-to-browser-readablestream/package.json
+++ b/packages/it-to-browser-readablestream/package.json
@@ -50,5 +50,8 @@
   },
   "devDependencies": {
     "aegir": "^42.2.5"
+  },
+  "dependencies": {
+    "get-iterator": "^2.0.1"
   }
 }

--- a/packages/it-to-browser-readablestream/src/index.ts
+++ b/packages/it-to-browser-readablestream/src/index.ts
@@ -25,10 +25,14 @@ interface SourceExt {
 
 type Source<T> = SourceExt & UnderlyingSource<T>
 
+import { getIterator } from 'get-iterator'
+
 /**
  * Converts an (async) iterator into a WHATWG ReadableStream
  */
-export default function itToBrowserReadableStream <T extends ArrayBufferView> (source: AsyncIterator<T> | Iterator<T>, queuingStrategy: QueuingStrategy<T> = {}): ReadableStream<T> {
+export default function itToBrowserReadableStream <T extends ArrayBufferView> (source: AsyncIterable<T> | Iterable<T>, queuingStrategy: QueuingStrategy<T> = {}): ReadableStream<T> {
+  const iter = getIterator<T>(source)
+
   const s: Source<ArrayBufferView> = {
     _cancelled: false,
 
@@ -37,7 +41,7 @@ export default function itToBrowserReadableStream <T extends ArrayBufferView> (s
     },
     async pull (controller) {
       try {
-        const { value, done } = await source.next()
+        const { value, done } = await iter.next()
 
         if (this._cancelled) {
           return

--- a/packages/it-to-browser-readablestream/src/index.ts
+++ b/packages/it-to-browser-readablestream/src/index.ts
@@ -19,13 +19,13 @@
  * ```
  */
 
+import { getIterator } from 'get-iterator'
+
 interface SourceExt {
   _cancelled: boolean
 }
 
 type Source<T> = SourceExt & UnderlyingSource<T>
-
-import { getIterator } from 'get-iterator'
 
 /**
  * Converts an (async) iterator into a WHATWG ReadableStream

--- a/packages/it-to-browser-readablestream/test/index.spec.ts
+++ b/packages/it-to-browser-readablestream/test/index.spec.ts
@@ -10,7 +10,7 @@ async function all <T> (stream: ReadableStream<T>): Promise<T[]> {
     while (true) {
       const { done, value } = await reader.read()
 
-      if (done === true) {
+      if (done) {
         return output
       }
 
@@ -63,6 +63,7 @@ describe('it-to-browser-readable-stream', () => {
       Uint8Array.from([0, 1, 2, 3, 4])
     ]
 
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     const iter = await asyncValues(input)
     const stream = toBrowserReadbleStream(iter)
     const output = await all(stream)

--- a/packages/it-to-browser-readablestream/test/index.spec.ts
+++ b/packages/it-to-browser-readablestream/test/index.spec.ts
@@ -1,8 +1,72 @@
 import { expect } from 'aegir/chai'
 import toBrowserReadbleStream from '../src/index.js'
 
+async function all <T> (stream: ReadableStream<T>): Promise<T[]> {
+  const output: T[] = []
+
+  const reader = stream.getReader()
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+
+      if (done === true) {
+        return output
+      }
+
+      if (value != null) {
+        output.push(value)
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+function * values <T> (vals: T[]): Generator<T, void, undefined> {
+  yield * vals
+}
+
+async function * asyncValues <T> (vals: T[]): AsyncIterable<T> {
+  yield * values(vals)
+}
+
 describe('it-to-browser-readable-stream', () => {
   it('should export something', async () => {
     expect(typeof toBrowserReadbleStream).to.equal('function')
+  })
+
+  it('should convert an iterator of bytes', async () => {
+    const input = [
+      Uint8Array.from([0, 1, 2, 3, 4])
+    ]
+
+    const stream = toBrowserReadbleStream(values(input))
+    const output = await all(stream)
+
+    expect(output).to.deep.equal(input)
+  })
+
+  it('should convert an async iterator of bytes', async () => {
+    const input = [
+      Uint8Array.from([0, 1, 2, 3, 4])
+    ]
+
+    const stream = toBrowserReadbleStream(asyncValues(input))
+    const output = await all(stream)
+
+    expect(output).to.deep.equal(input)
+  })
+
+  it('should convert an async iterable of bytes', async () => {
+    const input = [
+      Uint8Array.from([0, 1, 2, 3, 4])
+    ]
+
+    const iter = await asyncValues(input)
+    const stream = toBrowserReadbleStream(iter)
+    const output = await all(stream)
+
+    expect(output).to.deep.equal(input)
   })
 })


### PR DESCRIPTION
Accept iterators and iterables to browser readable stream.

Fixes #123