### PR TITLE
fix: re-export the Options type from fast-glob

### DIFF
--- a/packages/it-glob/src/index.ts
+++ b/packages/it-glob/src/index.ts
@@ -26,6 +26,8 @@ import path from 'node:path'
 import fastGlob from 'fast-glob'
 import type { Options } from 'fast-glob'
 
+export type { Options }
+
 /**
  * Async iterable filename pattern matcher
  */


### PR DESCRIPTION
Allow consumers to reuse the Options type without having to depend on `fast-glob` too.