### PR TITLE
fix: unhanded promise rejection in it-byte-stream

### DIFF
--- a/packages/it-byte-stream/src/pushable.ts
+++ b/packages/it-byte-stream/src/pushable.ts
@@ -58,6 +58,9 @@ class QueuelessPushable <T> implements Pushable<T> {
     this.ended = true
 
     if (err != null) {
+      // this can cause unhandled promise rejections if nothing is awaiting the
+      // next value so attach a dummy catch listener to the promise
+      this.haveNext.promise.catch(() => {})
       this.haveNext.reject(err)
     }
 


### PR DESCRIPTION
If no consumer is listening for the next value, and the underlying stream aborts, an unhandled promise rejection can occur.

Instead, add a `.catch` listener so the UPR doesn't occur, the rejection will be processed next time a consumer tries to read a value.