### PR TITLE
feat: add .name property to errors

### DIFF
--- a/packages/it-byte-stream/src/errors.ts
+++ b/packages/it-byte-stream/src/errors.ts
@@ -1,4 +1,3 @@
-
 /**
  * The incoming stream ended before the expected number of bytes were read
  */

--- a/packages/it-byte-stream/src/errors.ts
+++ b/packages/it-byte-stream/src/errors.ts
@@ -1,0 +1,8 @@
+
+/**
+ * The incoming stream ended before the expected number of bytes were read
+ */
+export class UnexpectedEOFError extends Error {
+  name = 'UnexpectedEOFError'
+  code = 'ERR_UNEXPECTED_EOF'
+}

--- a/packages/it-byte-stream/src/index.ts
+++ b/packages/it-byte-stream/src/index.ts
@@ -23,8 +23,8 @@
 
 import { queuelessPushable } from 'it-queueless-pushable'
 import { Uint8ArrayList } from 'uint8arraylist'
+import { UnexpectedEOFError } from './errors.js'
 import type { Duplex } from 'it-stream-types'
-import { UnexpectedEOFError } from './errors'
 
 /**
  * @deprecated This will not be exported in a future release

--- a/packages/it-byte-stream/src/index.ts
+++ b/packages/it-byte-stream/src/index.ts
@@ -24,6 +24,7 @@
 import { queuelessPushable } from 'it-queueless-pushable'
 import { Uint8ArrayList } from 'uint8arraylist'
 import type { Duplex } from 'it-stream-types'
+import { UnexpectedEOFError } from './errors'
 
 /**
  * @deprecated This will not be exported in a future release
@@ -143,7 +144,7 @@ export function byteStream <Stream extends Duplex<any, any, any>> (duplex: Strea
           ])
 
           if (done === true) {
-            throw new CodeError('unexpected end of input', 'ERR_UNEXPECTED_EOF')
+            throw new UnexpectedEOFError('unexpected end of input')
           }
 
           readBuffer.append(value)

--- a/packages/it-byte-stream/src/index.ts
+++ b/packages/it-byte-stream/src/index.ts
@@ -25,6 +25,9 @@ import { queuelessPushable } from 'it-queueless-pushable'
 import { Uint8ArrayList } from 'uint8arraylist'
 import type { Duplex } from 'it-stream-types'
 
+/**
+ * @deprecated This will not be exported in a future release
+ */
 export class CodeError extends Error {
   public readonly code: string
 
@@ -34,12 +37,16 @@ export class CodeError extends Error {
   }
 }
 
+/**
+ * @deprecated This will not be exported in a future release
+ */
 export class AbortError extends CodeError {
   public readonly type: string
 
   constructor (message: string) {
     super(message, 'ABORT_ERR')
     this.type = 'aborted'
+    this.name = 'AbortError'
   }
 }
 

--- a/packages/it-length-prefixed-stream/src/errors.ts
+++ b/packages/it-length-prefixed-stream/src/errors.ts
@@ -1,0 +1,33 @@
+/**
+ * The reported length of the next data message was not a positive integer
+ */
+export class InvalidMessageLengthError extends Error {
+  name = 'InvalidMessageLengthError'
+  code = 'ERR_INVALID_MSG_LENGTH'
+}
+
+/**
+ * The reported length of the next data message was larger than the configured
+ * max allowable value
+ */
+export class InvalidDataLengthError extends Error {
+  name = 'InvalidDataLengthError'
+  code = 'ERR_MSG_DATA_TOO_LONG'
+}
+
+/**
+ * The varint used to specify the length of the next data message contained more
+ * bytes than the configured max allowable value
+ */
+export class InvalidDataLengthLengthError extends Error {
+  name = 'InvalidDataLengthLengthError'
+  code = 'ERR_MSG_LENGTH_TOO_LONG'
+}
+
+/**
+ * The incoming stream ended before the expected number of bytes were read
+ */
+export class UnexpectedEOFError extends Error {
+  name = 'UnexpectedEOFError'
+  code = 'ERR_UNEXPECTED_EOF'
+}

--- a/packages/it-length-prefixed-stream/src/errors.ts
+++ b/packages/it-length-prefixed-stream/src/errors.ts
@@ -23,11 +23,3 @@ export class InvalidDataLengthLengthError extends Error {
   name = 'InvalidDataLengthLengthError'
   code = 'ERR_MSG_LENGTH_TOO_LONG'
 }
-
-/**
- * The incoming stream ended before the expected number of bytes were read
- */
-export class UnexpectedEOFError extends Error {
-  name = 'UnexpectedEOFError'
-  code = 'ERR_UNEXPECTED_EOF'
-}

--- a/packages/it-length-prefixed-stream/src/index.ts
+++ b/packages/it-length-prefixed-stream/src/index.ts
@@ -27,15 +27,7 @@ import { byteStream, type ByteStreamOpts } from 'it-byte-stream'
 import * as varint from 'uint8-varint'
 import { Uint8ArrayList } from 'uint8arraylist'
 import type { Duplex } from 'it-stream-types'
-
-class CodeError extends Error {
-  public readonly code: string
-
-  constructor (message: string, code: string) {
-    super(message)
-    this.code = code
-  }
-}
+import { InvalidDataLengthError, InvalidDataLengthLengthError, InvalidMessageLengthError } from './errors'
 
 export interface AbortOptions {
   signal?: AbortSignal
@@ -104,8 +96,12 @@ export function lpStream <Stream extends Duplex<any, any, any>> (duplex: Stream,
           throw err
         }
 
+        if (dataLength < 0) {
+          throw new InvalidMessageLengthError('Invalid message length')
+        }
+
         if (opts?.maxLengthLength != null && lengthBuffer.byteLength > opts.maxLengthLength) {
-          throw new CodeError('message length length too long', 'ERR_MSG_LENGTH_TOO_LONG')
+          throw new InvalidDataLengthLengthError('message length length too long')
         }
 
         if (dataLength > -1) {
@@ -114,7 +110,7 @@ export function lpStream <Stream extends Duplex<any, any, any>> (duplex: Stream,
       }
 
       if (opts?.maxDataLength != null && dataLength > opts.maxDataLength) {
-        throw new CodeError('message length too long', 'ERR_MSG_DATA_TOO_LONG')
+        throw new InvalidDataLengthError('message length too long')
       }
 
       return bytes.read(dataLength, options)

--- a/packages/it-length-prefixed-stream/src/index.ts
+++ b/packages/it-length-prefixed-stream/src/index.ts
@@ -26,8 +26,8 @@
 import { byteStream, type ByteStreamOpts } from 'it-byte-stream'
 import * as varint from 'uint8-varint'
 import { Uint8ArrayList } from 'uint8arraylist'
+import { InvalidDataLengthError, InvalidDataLengthLengthError, InvalidMessageLengthError } from './errors.js'
 import type { Duplex } from 'it-stream-types'
-import { InvalidDataLengthError, InvalidDataLengthLengthError, InvalidMessageLengthError } from './errors'
 
 export interface AbortOptions {
   signal?: AbortSignal


### PR DESCRIPTION
Adds a .name property to errors used as rejection reasons.