### PR TITLE
feat: add limit for incoming message sizes

### DIFF
--- a/packages/it-ndjson/src/errors.ts
+++ b/packages/it-ndjson/src/errors.ts
@@ -1,0 +1,7 @@
+/**
+ * A serialized message was received that was too large
+ */
+export class InvalidMessageLengthError extends Error {
+  name = 'InvalidMessageLengthError'
+  code = 'ERR_INVALID_MESSAGE_LENGTH'
+}

--- a/packages/it-ndjson/src/index.ts
+++ b/packages/it-ndjson/src/index.ts
@@ -24,3 +24,5 @@
 
 export { default as parse } from './parse.js'
 export { default as stringify } from './stringify.js'
+
+export type { ParseOptions } from './parse.js'


### PR DESCRIPTION
To prevent stream produces sending us streams of messages that grow too large, add an option to limit the incoming message buffer size.