### PR TITLE
fix: allow early return

### DIFF
--- a/packages/it-queueless-pushable/src/index.ts
+++ b/packages/it-queueless-pushable/src/index.ts
@@ -111,7 +111,11 @@ class QueuelessPushable <T> implements Pushable<T> {
       value: undefined
     }
 
-    await this._push(undefined)
+    this.ended = true
+    this.nextResult = result
+
+    // let the consumer know we have a new value
+    this.haveNext.resolve()
 
     return result
   }

--- a/packages/it-queueless-pushable/test/index.spec.ts
+++ b/packages/it-queueless-pushable/test/index.spec.ts
@@ -91,6 +91,24 @@ describe('it-queueless-pushable', () => {
     await expect(all(pushable)).to.eventually.be.ok()
   })
 
+  it('should return early', async () => {
+    const pushable = queuelessPushable<string>()
+
+    void pushable.push('hello')
+    void pushable.push('world')
+
+    let output: string | undefined
+
+    for await (const str of pushable) {
+      if (str === 'hello') {
+        output = str
+        break
+      }
+    }
+
+    expect(output).to.equal('hello')
+  })
+
   it('should not be pushable after ending', async () => {
     const pushable = queuelessPushable<string>()
 


### PR DESCRIPTION
Fixes the return function to allow breaking out of a `for await..of` loop.