### PR TITLE
fix!: remove AbortOptions exports

### DIFF
--- a/packages/it-byte-stream/package.json
+++ b/packages/it-byte-stream/package.json
@@ -136,6 +136,7 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "abort-error": "^1.0.1",
     "it-queueless-pushable": "^1.0.0",
     "it-stream-types": "^2.0.2",
     "uint8arraylist": "^2.4.8"

--- a/packages/it-byte-stream/src/index.ts
+++ b/packages/it-byte-stream/src/index.ts
@@ -21,39 +21,12 @@
  * ```
  */
 
+import { AbortError } from 'abort-error'
 import { queuelessPushable } from 'it-queueless-pushable'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { UnexpectedEOFError } from './errors.js'
+import type { AbortOptions } from 'abort-error'
 import type { Duplex } from 'it-stream-types'
-
-/**
- * @deprecated This will not be exported in a future release
- */
-export class CodeError extends Error {
-  public readonly code: string
-
-  constructor (message: string, code: string) {
-    super(message)
-    this.code = code
-  }
-}
-
-/**
- * @deprecated This will not be exported in a future release
- */
-export class AbortError extends CodeError {
-  public readonly type: string
-
-  constructor (message: string) {
-    super(message, 'ABORT_ERR')
-    this.type = 'aborted'
-    this.name = 'AbortError'
-  }
-}
-
-export interface AbortOptions {
-  signal?: AbortSignal
-}
 
 export interface ByteStream <Stream = unknown> {
   /**

--- a/packages/it-cbor-stream/package.json
+++ b/packages/it-cbor-stream/package.json
@@ -137,6 +137,7 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "abort-error": "^1.0.1",
     "cborg": "^4.2.8",
     "it-length-prefixed-stream": "^1.0.0",
     "it-stream-types": "^2.0.2"

--- a/packages/it-cbor-stream/src/index.ts
+++ b/packages/it-cbor-stream/src/index.ts
@@ -24,13 +24,10 @@
 
 import { encode, decode } from 'cborg'
 import { lpStream } from 'it-length-prefixed-stream'
+import type { AbortOptions } from 'abort-error'
 import type { EncodeOptions, DecodeOptions } from 'cborg/interface'
 import type { LengthPrefixedStreamOpts } from 'it-length-prefixed-stream'
 import type { Duplex } from 'it-stream-types'
-
-export interface AbortOptions {
-  signal?: AbortSignal
-}
 
 /**
  * Convenience methods for working with CBOR streams

--- a/packages/it-length-prefixed-stream/package.json
+++ b/packages/it-length-prefixed-stream/package.json
@@ -136,6 +136,7 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "abort-error": "^1.0.1",
     "it-byte-stream": "^1.0.0",
     "it-stream-types": "^2.0.2",
     "uint8-varint": "^2.0.4",

--- a/packages/it-length-prefixed-stream/src/index.ts
+++ b/packages/it-length-prefixed-stream/src/index.ts
@@ -27,11 +27,8 @@ import { byteStream, type ByteStreamOpts } from 'it-byte-stream'
 import * as varint from 'uint8-varint'
 import { Uint8ArrayList } from 'uint8arraylist'
 import { InvalidDataLengthError, InvalidDataLengthLengthError, InvalidMessageLengthError } from './errors.js'
+import type { AbortOptions } from 'abort-error'
 import type { Duplex } from 'it-stream-types'
-
-export interface AbortOptions {
-  signal?: AbortSignal
-}
 
 export interface LengthPrefixedStream <Stream = unknown> {
   /**

--- a/packages/it-ndjson-stream/package.json
+++ b/packages/it-ndjson-stream/package.json
@@ -136,6 +136,7 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "abort-error": "^1.0.1",
     "it-ndjson": "^1.0.0",
     "it-queueless-pushable": "^1.0.0",
     "it-stream-types": "^2.0.2",

--- a/packages/it-ndjson-stream/src/index.ts
+++ b/packages/it-ndjson-stream/src/index.ts
@@ -27,12 +27,9 @@ import { parse } from 'it-ndjson'
 import { queuelessPushable } from 'it-queueless-pushable'
 import { raceSignal } from 'race-signal'
 import { UnexpectedEOFError } from './errors.js'
+import type { AbortOptions } from 'abort-error'
 import type { ParseOptions } from 'it-ndjson'
 import type { Duplex } from 'it-stream-types'
-
-export interface AbortOptions {
-  signal?: AbortSignal
-}
 
 export interface NDJSONStream <T = any, Stream = unknown> {
   /**

--- a/packages/it-protobuf-stream/package.json
+++ b/packages/it-protobuf-stream/package.json
@@ -138,6 +138,7 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "abort-error": "^1.0.1",
     "it-length-prefixed-stream": "^1.0.0",
     "it-stream-types": "^2.0.2",
     "uint8arraylist": "^2.4.8"

--- a/packages/it-protobuf-stream/src/index.ts
+++ b/packages/it-protobuf-stream/src/index.ts
@@ -26,13 +26,10 @@
  */
 
 import { lpStream } from 'it-length-prefixed-stream'
+import type { AbortOptions } from 'abort-error'
 import type { LengthPrefixedStreamOpts } from 'it-length-prefixed-stream'
 import type { Duplex } from 'it-stream-types'
 import type { Uint8ArrayList } from 'uint8arraylist'
-
-export interface AbortOptions {
-  signal?: AbortSignal
-}
 
 /**
  * A protobuf decoder - takes a byte array and returns an object

--- a/packages/it-queueless-pushable/package.json
+++ b/packages/it-queueless-pushable/package.json
@@ -136,6 +136,7 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "abort-error": "^1.0.1",
     "p-defer": "^4.0.1",
     "race-signal": "^1.1.3"
   },

--- a/packages/it-queueless-pushable/src/index.ts
+++ b/packages/it-queueless-pushable/src/index.ts
@@ -30,10 +30,7 @@
 
 import deferred, { type DeferredPromise } from 'p-defer'
 import { raceSignal, type RaceSignalOptions } from 'race-signal'
-
-export interface AbortOptions {
-  signal?: AbortSignal
-}
+import type { AbortOptions } from 'abort-error'
 
 export interface Pushable<T> extends AsyncGenerator<T, void, unknown> {
   /**


### PR DESCRIPTION
Re-use the `AbortOptions` export from the `abort-error` module.

BREAKING CHANGE: the `AbortOptions` interface is no longer exported, use the one from `abort-error` instead