### PR TITLE
fix: re-throw error on write to errored pushable

### DIFF
--- a/packages/it-ndjson-stream/src/index.ts
+++ b/packages/it-ndjson-stream/src/index.ts
@@ -72,11 +72,7 @@ export function ndjsonStream <T = any, Stream extends Duplex<any, any, any> = Du
     read: async (options?: AbortOptions) => {
       const result = await raceSignal(input.next(), options?.signal)
 
-      if (result.done === true) {
-        throw new UnexpectedEOFError('unexpected end of input')
-      }
-
-      if (result.value == null) {
+      if (result.done === true || result.value == null) {
         throw new UnexpectedEOFError('unexpected end of input')
       }
 

--- a/packages/it-queueless-pushable/src/index.ts
+++ b/packages/it-queueless-pushable/src/index.ts
@@ -52,6 +52,7 @@ class QueuelessPushable <T> implements Pushable<T> {
   private haveNext: DeferredPromise<void>
   private ended: boolean
   private nextResult: IteratorResult<T> | undefined
+  private error?: Error
 
   constructor () {
     this.ended = false
@@ -86,6 +87,7 @@ class QueuelessPushable <T> implements Pushable<T> {
 
   async throw (err?: Error): Promise<IteratorReturnResult<undefined>> {
     this.ended = true
+    this.error = err
 
     if (err != null) {
       // this can cause unhandled promise rejections if nothing is awaiting the
@@ -132,7 +134,7 @@ class QueuelessPushable <T> implements Pushable<T> {
 
   private async _push (value?: T, options?: AbortOptions & RaceSignalOptions): Promise<void> {
     if (value != null && this.ended) {
-      throw new Error('Cannot push value onto an ended pushable')
+      throw this.error ?? new Error('Cannot push value onto an ended pushable')
     }
 
     // wait for all values to be read

--- a/packages/it-queueless-pushable/test/index.spec.ts
+++ b/packages/it-queueless-pushable/test/index.spec.ts
@@ -121,6 +121,14 @@ describe('it-queueless-pushable', () => {
     await expect(pushable.push('nope!')).to.eventually.be.rejectedWith('Cannot push value onto an ended pushable')
   })
 
+  it('should re-throw error when attempting to write to errored pushable', async () => {
+    const err = new Error('Urk!')
+    const pushable = queuelessPushable<string>()
+    void pushable.throw(err)
+
+    await expect(pushable.push('derp')).to.eventually.be.rejectedWith(err)
+  })
+
   it('should push in order even it promises are unawaited', async () => {
     const pushable = queuelessPushable<string>()
 


### PR DESCRIPTION
To make errors more transparent, when a pushable is ended due to
an error, re-throw that error when we try to interact with it again.