### PR TITLE
feat!: return null from bytestream when stream closes

### DIFF
--- a/packages/it-byte-stream/package.json
+++ b/packages/it-byte-stream/package.json
@@ -139,6 +139,7 @@
     "abort-error": "^1.0.1",
     "it-queueless-pushable": "^1.0.0",
     "it-stream-types": "^2.0.2",
+    "race-signal": "^1.1.3",
     "uint8arraylist": "^2.4.8"
   },
   "devDependencies": {

--- a/packages/it-byte-stream/test/index.spec.ts
+++ b/packages/it-byte-stream/test/index.spec.ts
@@ -48,6 +48,31 @@ const tests: Record<string, Test<any>> = {
   }
 }
 
+describe('it-byte-stream', () => {
+  it('returns null if underlying stream is empty', async () => {
+    const b = byteStream({
+      source: [],
+      sink: async () => {}
+    })
+
+    const res = await b.read()
+
+    expect(res).to.be.null()
+  })
+
+  it('throws EOF if underlying stream is empty and bytes are specified', async () => {
+    const b = byteStream({
+      source: [],
+      sink: async () => {}
+    })
+
+    await expect(b.read({
+      bytes: 10
+    })).to.eventually.be.rejected
+      .with.property('name', 'UnexpectedEOFError')
+  })
+})
+
 Object.keys(tests).forEach(key => {
   const test = tests[key]
 
@@ -70,7 +95,7 @@ Object.keys(tests).forEach(key => {
       const data = test.from('ww')
 
       void b.write(data)
-      const res = await b.read(2)
+      const res = await b.read({ bytes: 2 })
 
       expect(res.subarray()).to.equalBytes(data.subarray())
     })
@@ -81,8 +106,8 @@ Object.keys(tests).forEach(key => {
       const r = test.from('w')
       void b.write(data)
 
-      const r1 = await b.read(1)
-      const r2 = await b.read(1)
+      const r1 = await b.read({ bytes: 1 })
+      const r2 = await b.read({ bytes: 1 })
 
       expect(r.subarray()).to.equalBytes(r1.subarray())
       expect(r.subarray()).to.equalBytes(r2.subarray())

--- a/packages/it-length-prefixed-stream/src/index.ts
+++ b/packages/it-length-prefixed-stream/src/index.ts
@@ -81,7 +81,10 @@ export function lpStream <Stream extends Duplex<any, any, any>> (duplex: Stream,
 
       while (true) {
         // read one byte at a time until we can decode a varint
-        lengthBuffer.append(await bytes.read(1, options))
+        lengthBuffer.append(await bytes.read({
+          ...options,
+          bytes: 1
+        }))
 
         try {
           dataLength = decodeLength(lengthBuffer)
@@ -110,7 +113,10 @@ export function lpStream <Stream extends Duplex<any, any, any>> (duplex: Stream,
         throw new InvalidDataLengthError('message length too long')
       }
 
-      return bytes.read(dataLength, options)
+      return bytes.read({
+        ...options,
+        bytes: dataLength
+      })
     },
     write: async (data, options?: AbortOptions) => {
       // encode, write

--- a/packages/it-length-prefixed-stream/test/index.spec.ts
+++ b/packages/it-length-prefixed-stream/test/index.spec.ts
@@ -83,7 +83,7 @@ Object.keys(tests).forEach(key => {
       await expect(lp.read({
         signal: AbortSignal.timeout(10)
       })).to.eventually.be.rejected()
-        .with.property('message', 'Read aborted')
+        .with.property('name', 'AbortError')
     })
 
     it('waits for read when writing', async () => {
@@ -116,7 +116,7 @@ Object.keys(tests).forEach(key => {
       const length = test.allocUnsafe(4)
       test.writeInt32BE(length, data.length, 0)
       const expected = test.concat([length, data])
-      expect(res.subarray()).to.equalBytes(expected.subarray())
+      expect(res?.subarray()).to.equalBytes(expected.subarray())
     })
 
     it('lp fixed decode', async () => {


### PR DESCRIPTION
If a required number of bytes is not specified, and the underlying stream closes without yielding any bytes, return `null` instead of throwing `EOF`.

BREAKING CHANGE: if the underlying stream closes without yielding any bytes and we are not waiting for a required number of bytes, `byteStream.read` will now return `null` instead of an empty `Uint8ArrayList`