### PR TITLE
fix: handle throw during onward yield

### DIFF
--- a/packages/it-parallel/src/index.ts
+++ b/packages/it-parallel/src/index.ts
@@ -222,6 +222,14 @@ export default async function * parallel <T> (source: Iterable<() => Promise<T>>
       yield * yieldUnOrderedValues()
     }
 
+    if (sourceErr != null) {
+      // if the source yields an array that is `yield *`, it can throw while the
+      // onward consumer is processing the array contents - make sure we
+      // propagate the error
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw sourceErr
+    }
+
     if (sourceFinished && ops.length === 0) {
       // not waiting for any results and no more tasks so we are done
       break


### PR DESCRIPTION
If an iterable passed to `it-parallel` yields an list of values, and it throws during a delay processing those values, we need to ensure we propagate that error, otherwise calling code can stall.