### PR TITLE
fix: abort awaiting pushable add when no longer yielding values

### DIFF
--- a/packages/it-merge/package.json
+++ b/packages/it-merge/package.json
@@ -148,6 +148,7 @@
   },
   "devDependencies": {
     "aegir": "^46.0.1",
+    "delay": "^6.0.0",
     "it-all": "^3.0.0"
   }
 }


### PR DESCRIPTION
If the consumer stops consuming from the stream, abort the add of further values to not cause hanging promises.