### PR TITLE
fix: require connection to invoke remote methods

### DIFF
--- a/packages/it-rpc/src/errors.ts
+++ b/packages/it-rpc/src/errors.ts
@@ -67,3 +67,10 @@ export class MissingCallbackError extends Error {
     this.name = 'MissingCallbackError'
   }
 }
+
+export class NotConnectedError extends Error {
+  constructor (message = 'Not connected') {
+    super(message)
+    this.name = 'NotConnectedError'
+  }
+}

--- a/packages/it-rpc/test/custom-types.spec.ts
+++ b/packages/it-rpc/test/custom-types.spec.ts
@@ -32,7 +32,7 @@ const codec: ValueCodec<MyClass> = {
   }
 }
 
-describe('basics', () => {
+describe('custom types', () => {
   let serverRPC: RPC
   let clientRPC: RPC
   let sender: typeof target

--- a/packages/it-rpc/test/index.spec.ts
+++ b/packages/it-rpc/test/index.spec.ts
@@ -93,4 +93,40 @@ describe('basics', () => {
   it('should retain object context when invoking a generator', async () => {
     await expect(all(sender.generatorContextAccess())).to.eventually.deep.equal([true])
   })
+
+  it('should require connection to invoke methods', async () => {
+    const clientRPC = rpc()
+    const sender = clientRPC.createClient<typeof target>('target')
+
+    await expect(sender.hello()).to.eventually.be.rejected
+      .with.property('name', 'NotConnectedError')
+  })
+
+  it('should require connection to invoke a generator', async () => {
+    const clientRPC = rpc()
+    const sender = clientRPC.createClient<typeof target>('target')
+
+    await expect(all(sender.generatorContextAccess())).to.eventually.be.rejected
+      .with.property('name', 'NotConnectedError')
+  })
+
+  it('should require connection to throw from a generator', async () => {
+    const clientRPC = rpc()
+    const sender = clientRPC.createClient<typeof target>('target')
+
+    const gen = sender.generatorContextAccess()
+
+    await expect(gen.throw(new Error('wat'))).to.eventually.be.rejected
+      .with.property('name', 'NotConnectedError')
+  })
+
+  it('should require connection to return from a generator', async () => {
+    const clientRPC = rpc()
+    const sender = clientRPC.createClient<typeof target>('target')
+
+    const gen = sender.generatorContextAccess()
+
+    await expect(gen.return(true)).to.eventually.be.rejected
+      .with.property('name', 'NotConnectedError')
+  })
 })


### PR DESCRIPTION
If there is no onward stream to send messages to, the internal message queue grows until the process falls over.

Throw a `NotConnectedError` if there is no remote to send messages to.