### PR TITLE
fix: remove any-signal

### DIFF
--- a/packages/it-rpc/package.json
+++ b/packages/it-rpc/package.json
@@ -141,7 +141,6 @@
   },
   "dependencies": {
     "abort-error": "^1.0.1",
-    "any-signal": "^4.1.1",
     "cborg": "^4.2.11",
     "it-length-prefixed": "^10.0.1",
     "it-pushable": "^3.2.3",

--- a/packages/it-rpc/src/codecs/1030-function.ts
+++ b/packages/it-rpc/src/codecs/1030-function.ts
@@ -1,4 +1,3 @@
-import { anySignal } from 'any-signal'
 import { decode, encode } from 'cborg'
 import { nanoid } from 'nanoid'
 import pDefer from 'p-defer'
@@ -35,7 +34,7 @@ const transformer: ValueCodec<(...args: any[]) => any> = {
         invocation.children.set(scope, callbackInvocation)
         args = args.map(val => codec.toValue(val, null, callbackInvocation))
 
-        const signal = anySignal(callbackInvocation.abortSignals)
+        const signal = AbortSignal.any(callbackInvocation.abortSignals)
         signal.addEventListener('abort', () => {
           pushable.push(RPCMessage.encode({
             type: MessageType.abortCallbackInvocation,
@@ -62,7 +61,6 @@ const transformer: ValueCodec<(...args: any[]) => any> = {
           reject(err)
         }).finally(() => {
           invocation.children.delete(scope)
-          signal.clear()
         })
       })
     }

--- a/packages/it-rpc/src/index.ts
+++ b/packages/it-rpc/src/index.ts
@@ -208,7 +208,6 @@
  */
 
 import { AbortError } from 'abort-error'
-import { anySignal } from 'any-signal'
 import { decode as lpDecode, encode as lpEncode } from 'it-length-prefixed'
 import { pushable } from 'it-pushable'
 import { nanoid } from 'nanoid'
@@ -790,7 +789,7 @@ class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
                 })
               }))
 
-              const signal = anySignal(invocation.abortSignals)
+              const signal = AbortSignal.any(invocation.abortSignals)
               signal.addEventListener('abort', () => {
                 self.output.push(RPCMessage.encode({
                   type: MessageType.abortMethodInvocation,
@@ -812,7 +811,6 @@ class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
                 reject(err)
               }).finally(() => {
                 self.invocations.delete(scope)
-                signal.clear()
               })
 
               if (!self.connected) {
@@ -864,7 +862,7 @@ class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
                   signals.push(timeout)
                 }
 
-                const signal = anySignal(signals)
+                const signal = AbortSignal.any(signals)
 
                 try {
                   const gen = await raceSignal<AsyncGenerator<any>>(invocation.result.promise, signal)
@@ -883,8 +881,6 @@ class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
                   }
 
                   throw err
-                } finally {
-                  signal.clear()
                 }
               },
               async throw (err: any) {
@@ -900,7 +896,7 @@ class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
                   signals.push(timeout)
                 }
 
-                const signal = anySignal(signals)
+                const signal = AbortSignal.any(signals)
 
                 try {
                   const gen = await raceSignal<AsyncGenerator<any>>(invocation.result.promise, signal)
@@ -921,8 +917,6 @@ class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
                   }
 
                   throw e
-                } finally {
-                  signal.clear()
                 }
               },
               async return (value: any) {
@@ -938,7 +932,7 @@ class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
                   signals.push(timeout)
                 }
 
-                const signal = anySignal(signals)
+                const signal = AbortSignal.any(signals)
 
                 try {
                   const gen = await raceSignal<AsyncGenerator<any>>(invocation.result.promise, signal)
@@ -957,8 +951,6 @@ class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
                   }
 
                   throw err
-                } finally {
-                  signal.clear()
                 }
               },
               [Symbol.asyncIterator]: () => asyncGenerator


### PR DESCRIPTION
We can now use `AbortSignal.any` ~~which has the advantage of not requiring cleanup~~.

Blocked on:

- https://github.com/nodejs/node/issues/54614
- https://github.com/denoland/deno/issues/24842
- etc