### PR TITLE
fix: typo in it-to-browser-readablestream readme

### DIFF
--- a/packages/it-to-browser-readablestream/README.md
+++ b/packages/it-to-browser-readablestream/README.md
@@ -22,7 +22,7 @@ repo and examine the changes made.
 
 -->
 
-Turns an (async)iterable into a W3C ReadbleStream.
+Turns an (async)iterable into a W3C ReadableStream.
 
 ## Example
 


### PR DESCRIPTION
Regenerates readme to fix typo.