### PR TITLE
fix!: Uint8Arrays are generic

### DIFF
--- a/packages/blob-to-it/src/index.ts
+++ b/packages/blob-to-it/src/index.ts
@@ -19,7 +19,7 @@
 
 import browserReadableStreamToIt from 'browser-readablestream-to-it'
 
-export default function blobToIt (blob: Blob): AsyncIterable<Uint8Array> {
+export default function blobToIt (blob: Blob): AsyncGenerator<Uint8Array<ArrayBuffer>> {
   if (typeof blob.stream === 'function') {
     return browserReadableStreamToIt(blob.stream())
   }

--- a/packages/it-batched-bytes/package.json
+++ b/packages/it-batched-bytes/package.json
@@ -139,7 +139,7 @@
   },
   "dependencies": {
     "p-defer": "^4.0.1",
-    "uint8arraylist": "^2.4.8"
+    "uint8arraylist": "^3.0.1"
   },
   "devDependencies": {
     "aegir": "^48.0.1",

--- a/packages/it-batched-bytes/src/index.ts
+++ b/packages/it-batched-bytes/src/index.ts
@@ -70,15 +70,15 @@ export interface AsyncBatchedBytesOptions extends BatchedBytesOptions {
   yieldAfter?: number
 }
 
-export interface BatchedObjectsOptions<T> extends BatchedBytesOptions {
+export interface BatchedObjectsOptions<O, T extends ArrayBufferLike = ArrayBufferLike> extends BatchedBytesOptions {
   /**
    * This function should serialize the object and append the
    * result to the passed list
    */
-  serialize(object: T, list: Uint8ArrayList): void
+  serialize(object: O, list: Uint8ArrayList<T>): void
 }
 
-export interface AsyncBatchedObjectsOptions<T> extends AsyncBatchedBytesOptions, BatchedObjectsOptions<T> {
+export interface AsyncBatchedObjectsOptions<O, T extends ArrayBufferLike = ArrayBufferLike> extends AsyncBatchedBytesOptions, BatchedObjectsOptions<O, T> {
 
 }
 
@@ -87,14 +87,14 @@ export interface AsyncBatchedObjectsOptions<T> extends AsyncBatchedBytesOptions,
  * an internal buffer. Either once the buffer reaches the requested size
  * or the next event loop tick occurs, yield any bytes from the buffer.
  */
-function batchedBytes (source: Iterable<Uint8Array | Uint8ArrayList>, options?: BatchedBytesOptions): Iterable<Uint8Array>
-function batchedBytes (source: Iterable<Uint8Array | Uint8ArrayList> | AsyncIterable<Uint8Array | Uint8ArrayList>, options?: AsyncBatchedBytesOptions): AsyncIterable<Uint8Array>
-function batchedBytes <T> (source: Iterable<T>, options?: BatchedObjectsOptions<T>): Iterable<Uint8Array>
-function batchedBytes <T> (source: Iterable<T> | AsyncIterable<T>, options?: AsyncBatchedObjectsOptions<T>): AsyncIterable<Uint8Array>
-function batchedBytes <T = Uint8Array | Uint8ArrayList> (source: Iterable<T> | AsyncIterable<T>, options?: Partial<AsyncBatchedObjectsOptions<T>>): AsyncIterable<Uint8Array> | Iterable<Uint8Array> {
+function batchedBytes <T extends ArrayBufferLike = ArrayBufferLike> (source: Iterable<Uint8Array<T> | Uint8ArrayList<T>>, options?: BatchedBytesOptions): Iterable<Uint8Array<T>>
+function batchedBytes <T extends ArrayBufferLike = ArrayBufferLike> (source: Iterable<Uint8Array<T> | Uint8ArrayList<T>> | AsyncIterable<Uint8Array<T> | Uint8ArrayList<T>>, options?: AsyncBatchedBytesOptions): AsyncIterable<Uint8Array<T>>
+function batchedBytes <O, T extends ArrayBufferLike = ArrayBufferLike> (source: Iterable<O>, options?: BatchedObjectsOptions<O, T>): Iterable<Uint8Array<T>>
+function batchedBytes <O, T extends ArrayBufferLike = ArrayBufferLike> (source: Iterable<O> | AsyncIterable<O>, options?: AsyncBatchedObjectsOptions<O, T>): AsyncIterable<Uint8Array<T>>
+function batchedBytes <T extends ArrayBufferLike = ArrayBufferLike, O = Uint8Array<T> | Uint8ArrayList<T>> (source: Iterable<O> | AsyncIterable<O>, options?: Partial<AsyncBatchedObjectsOptions<O, T>>): AsyncIterable<Uint8Array<T | ArrayBuffer>> | Iterable<Uint8Array<T | ArrayBuffer>> {
   if (isAsyncIterable(source)) {
     return (async function * () {
-      let buffer = new Uint8ArrayList()
+      let buffer = new Uint8ArrayList<T>()
       let ended = false
       let deferred = defer()
 
@@ -144,7 +144,7 @@ function batchedBytes <T = Uint8Array | Uint8ArrayList> (source: Iterable<T> | A
         deferred = defer()
         if (buffer.byteLength > 0) {
           const b = buffer
-          buffer = new Uint8ArrayList()
+          buffer = new Uint8ArrayList<T>()
           yield b.subarray()
         }
       }
@@ -152,7 +152,7 @@ function batchedBytes <T = Uint8Array | Uint8ArrayList> (source: Iterable<T> | A
   }
 
   return (function * () {
-    const buffer = new Uint8ArrayList()
+    const buffer = new Uint8ArrayList<T>()
     let size = Number(options?.size ?? DEFAULT_BATCH_SIZE)
 
     if (isNaN(size) || size === 0 || size < 0) {

--- a/packages/it-buffer-stream/package.json
+++ b/packages/it-buffer-stream/package.json
@@ -142,6 +142,6 @@
   },
   "devDependencies": {
     "aegir": "^48.0.1",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^6.1.0"
   }
 }

--- a/packages/it-buffer-stream/src/index.ts
+++ b/packages/it-buffer-stream/src/index.ts
@@ -36,13 +36,13 @@
 
 import randomBytes from 'iso-random-stream/src/random.js'
 
-export interface BufferStreamOptions {
+export interface BufferStreamOptions<T extends ArrayBufferLike = ArrayBufferLike> {
   chunkSize?: number
-  collector?(arr: Uint8Array): void
-  generator?(length: number): Uint8Array | Promise<Uint8Array>
+  collector?(arr: Uint8Array<T>): void
+  generator?(length: number): Uint8Array<T> | Promise<Uint8Array<T>>
 }
 
-const defaultOptions: Required<BufferStreamOptions> = {
+const defaultOptions: Required<BufferStreamOptions<ArrayBufferLike>> = {
   chunkSize: 4096,
   collector: () => {},
   generator: async (size) => Promise.resolve(randomBytes(size))
@@ -51,7 +51,10 @@ const defaultOptions: Required<BufferStreamOptions> = {
 /**
  * An async iterable that emits buffers containing bytes up to a certain length
  */
-export default async function * bufferStream (limit: number, options: BufferStreamOptions = {}): AsyncGenerator<Uint8Array, void, unknown> {
+export default function bufferStream (limit: number): AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>
+export default function bufferStream (limit: number, options: Omit<BufferStreamOptions, 'generator'>): AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>
+export default function bufferStream <T extends ArrayBufferLike = ArrayBufferLike> (limit: number, options?: BufferStreamOptions<T>): AsyncGenerator<Uint8Array<T>, void, unknown>
+export default async function * bufferStream <T extends ArrayBufferLike = ArrayBufferLike> (limit: number, options: BufferStreamOptions<T> = {}): AsyncGenerator<Uint8Array<T | SharedArrayBuffer | ArrayBuffer>, void, unknown> {
   const opts: Required<BufferStreamOptions> = Object.assign({}, defaultOptions, options)
   let emitted = 0
 
@@ -68,7 +71,7 @@ export default async function * bufferStream (limit: number, options: BufferStre
     }
 
     let bytes = await opts.generator(nextChunkSize)
-    bytes = bytes.slice(0, nextChunkSize)
+    bytes = bytes.subarray(0, nextChunkSize)
 
     opts.collector(bytes)
     emitted += nextChunkSize

--- a/packages/it-buffer-stream/test/index.spec.ts
+++ b/packages/it-buffer-stream/test/index.spec.ts
@@ -36,8 +36,7 @@ describe('it-buffer-stream', () => {
 
   it('should allow collection of buffers', async () => {
     const expected = 100
-    // https://github.com/microsoft/TypeScript/issues/61793
-    let emitted: Uint8Array = new Uint8Array(0)
+    let emitted = new Uint8Array(0)
     const buffers = []
 
     for await (const buf of bufferStream(expected, {
@@ -53,13 +52,35 @@ describe('it-buffer-stream', () => {
 
   it('should allow generation of buffers', async () => {
     const expected = 100
-    // https://github.com/microsoft/TypeScript/issues/61793
-    let emitted: Uint8Array = new Uint8Array(0)
+    let emitted = new Uint8Array(0)
     const buffers = []
 
     for await (const buf of bufferStream(expected, {
       generator: (size) => {
         const output = new Uint8Array(size)
+        emitted = uint8ArrayConcat([emitted, output])
+
+        return output
+      }
+    })) {
+      buffers.push(buf)
+    }
+
+    expect(emitted).to.equalBytes(buffers[0])
+  })
+
+  it('should allow generation of buffers with non-default backing buffer', async function () {
+    if (globalThis.SharedArrayBuffer == null) {
+      this.skip()
+    }
+
+    const expected = 100
+    let emitted = new Uint8Array(0)
+    const buffers = []
+
+    for await (const buf of bufferStream(expected, {
+      generator: (size) => {
+        const output = new Uint8Array(new SharedArrayBuffer(size))
         emitted = uint8ArrayConcat([emitted, output])
 
         return output

--- a/packages/it-byte-stream/package.json
+++ b/packages/it-byte-stream/package.json
@@ -142,12 +142,12 @@
     "it-queueless-pushable": "^2.0.0",
     "it-stream-types": "^2.0.2",
     "race-signal": "^2.0.0",
-    "uint8arraylist": "^2.4.8"
+    "uint8arraylist": "^3.0.1"
   },
   "devDependencies": {
     "aegir": "^48.0.1",
     "delay": "^7.0.0",
     "it-pair": "^2.0.6",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^6.1.0"
   }
 }

--- a/packages/it-byte-stream/src/index.ts
+++ b/packages/it-byte-stream/src/index.ts
@@ -32,7 +32,7 @@ export interface ReadOptions extends AbortOptions {
   bytes: number
 }
 
-export interface ByteStream <Stream = unknown> {
+export interface ByteStream <Stream = unknown, T extends ArrayBufferLike = ArrayBufferLike> {
   /**
    * Read bytes from the stream.
    *
@@ -43,13 +43,13 @@ export interface ByteStream <Stream = unknown> {
    * If no required number of bytes is passed, this will return `null` if the
    * underlying stream closes before supplying any bytes.
    */
-  read(options: ReadOptions): Promise<Uint8ArrayList>
-  read(options?: AbortOptions): Promise<Uint8ArrayList | null>
+  read(options: ReadOptions): Promise<Uint8ArrayList<T>>
+  read(options?: AbortOptions): Promise<Uint8ArrayList<T> | null>
 
   /**
    * Write the passed bytes to the stream
    */
-  write(input: Uint8Array | Uint8ArrayList, options?: AbortOptions): Promise<void>
+  write(input: Uint8Array<T> | Uint8ArrayList<T>, options?: AbortOptions): Promise<void>
 
   /**
    * Returns the underlying stream
@@ -68,7 +68,7 @@ export interface ByteStreamOpts {
   yieldBytes?: boolean
 }
 
-export function byteStream <Stream extends Duplex<any, any, any>> (duplex: Stream, opts?: ByteStreamOpts): ByteStream<Stream> {
+export function byteStream <Stream extends Duplex<any, any, any>, T extends ArrayBufferLike = ArrayBufferLike> (duplex: Stream, opts?: ByteStreamOpts): ByteStream<Stream, T> {
   const write = queuelessPushable()
 
   duplex.sink(write).catch(async (err: Error) => {
@@ -91,9 +91,9 @@ export function byteStream <Stream extends Duplex<any, any, any>> (duplex: Strea
     source = duplex.source[Symbol.asyncIterator]()
   }
 
-  const readBuffer = new Uint8ArrayList()
+  const readBuffer = new Uint8ArrayList<T>()
 
-  const W: ByteStream<Stream> = {
+  const W: ByteStream<Stream, T> = {
     read: async (options?: ReadOptions) => {
       options?.signal?.throwIfAborted()
 

--- a/packages/it-cbor-stream/package.json
+++ b/packages/it-cbor-stream/package.json
@@ -149,7 +149,7 @@
     "it-map": "^3.0.0",
     "it-pair": "^2.0.6",
     "it-to-buffer": "^4.0.0",
-    "uint8-varint": "^2.0.4",
-    "uint8arrays": "^5.1.0"
+    "uint8-varint": "^3.0.0",
+    "uint8arrays": "^6.1.0"
   }
 }

--- a/packages/it-length-prefixed-stream/package.json
+++ b/packages/it-length-prefixed-stream/package.json
@@ -141,12 +141,12 @@
     "abort-error": "^1.0.2",
     "it-byte-stream": "^2.0.0",
     "it-stream-types": "^2.0.2",
-    "uint8-varint": "^2.0.4",
-    "uint8arraylist": "^2.4.8"
+    "uint8-varint": "^3.0.0",
+    "uint8arraylist": "^3.0.1"
   },
   "devDependencies": {
     "aegir": "^48.0.1",
     "it-pair": "^2.0.6",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^6.1.0"
   }
 }

--- a/packages/it-length-prefixed-stream/src/index.ts
+++ b/packages/it-length-prefixed-stream/src/index.ts
@@ -31,11 +31,11 @@ import type { AbortOptions } from 'abort-error'
 import type { ByteStreamOpts } from 'it-byte-stream'
 import type { Duplex } from 'it-stream-types'
 
-export interface LengthPrefixedStream <Stream = unknown> {
+export interface LengthPrefixedStream <Stream = unknown, T extends ArrayBufferLike = ArrayBufferLike> {
   /**
    * Read the next length-prefixed number of bytes from the stream
    */
-  read(options?: AbortOptions): Promise<Uint8ArrayList>
+  read(options?: AbortOptions): Promise<Uint8ArrayList<T>>
 
   /**
    * Write the passed bytes to the stream prefixed by their length

--- a/packages/it-length-prefixed-stream/test/index.spec.ts
+++ b/packages/it-length-prefixed-stream/test/index.spec.ts
@@ -32,8 +32,8 @@ const tests: Record<string, Test<any>> = {
     from: (str: string) => uint8ArrayFromString(str),
     alloc: (length: number, fill = 0) => uint8Alloc(length).fill(fill),
     allocUnsafe: (length: number) => uint8AllocUnsafe(length),
-    concat: (arrs: Buffer[], length?: number) => uint8ArrayConcat(arrs, length),
-    writeInt32BE: (buf: Buffer, value: number, offset: number) => {
+    concat: (arrs: Uint8Array[], length?: number) => uint8ArrayConcat(arrs, length),
+    writeInt32BE: (buf: Uint8Array, value: number, offset: number) => {
       new DataView(buf.buffer, buf.byteOffset, buf.byteLength).setInt32(offset, value, false)
     }
   },
@@ -46,6 +46,26 @@ const tests: Record<string, Test<any>> = {
       const data = new Uint8Array(4)
       new DataView(data.buffer, data.byteOffset, data.byteLength).setInt32(offset, value, false)
       buf.write(data, offset)
+    }
+  }
+}
+
+if (globalThis.SharedArrayBuffer != null) {
+  function toSharedArrayBuffer (arr: Uint8Array): Uint8Array {
+    const buf = new SharedArrayBuffer(arr.byteLength)
+    const out = new Uint8Array(buf)
+    out.set(arr, 0)
+
+    return out
+  }
+
+  tests['SharedArrayBuffer'] = {
+    from: (str: string) => toSharedArrayBuffer(uint8ArrayFromString(str)),
+    alloc: (length: number, fill = 0) => toSharedArrayBuffer(uint8Alloc(length).fill(fill)),
+    allocUnsafe: (length: number) => toSharedArrayBuffer(uint8AllocUnsafe(length)),
+    concat: (arrs: Uint8Array<SharedArrayBuffer>[], length?: number) => toSharedArrayBuffer(uint8ArrayConcat(arrs, length)),
+    writeInt32BE: (buf: Uint8Array<SharedArrayBuffer>, value: number, offset: number) => {
+      new DataView(buf.buffer, buf.byteOffset, buf.byteLength).setInt32(offset, value, false)
     }
   }
 }

--- a/packages/it-multipart/package.json
+++ b/packages/it-multipart/package.json
@@ -143,7 +143,7 @@
     "form-data": "^4.0.5",
     "it-drain": "^3.0.0",
     "node-fetch": "^3.3.2",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^6.1.0"
   },
   "browser": {
     "http": false,

--- a/packages/it-multipart/src/index.ts
+++ b/packages/it-multipart/src/index.ts
@@ -39,7 +39,7 @@ import type { IncomingMessage, IncomingHttpHeaders } from 'http'
 
 export interface Part {
   headers: IncomingHttpHeaders
-  body: AsyncIterable<Uint8Array>
+  body: AsyncIterable<Uint8Array<ArrayBuffer>>
 }
 
 /**
@@ -65,7 +65,7 @@ export default async function * multipart (request: IncomingMessage): AsyncGener
   })
 
   form.onPart = (part) => {
-    const body = pushable()
+    const body = pushable<Uint8Array<ArrayBuffer>>()
 
     part.on('data', buf => {
       body.push(buf)

--- a/packages/it-ndjson/package.json
+++ b/packages/it-ndjson/package.json
@@ -138,7 +138,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "uint8arraylist": "^2.4.8"
+    "uint8arraylist": "^3.0.1"
   },
   "devDependencies": {
     "aegir": "^48.0.1",

--- a/packages/it-ndjson/test/index.spec.ts
+++ b/packages/it-ndjson/test/index.spec.ts
@@ -11,7 +11,7 @@ async function * toAsyncIterator <T> (array: T[]): AsyncIterable<T> {
   }
 }
 
-function toUint8Array (str: string): Uint8Array {
+function toUint8Array (str: string): Uint8Array<ArrayBuffer> {
   const arr = new Uint8Array(str.length)
   for (let i = 0; i < str.length; i++) {
     arr[i] = str.charCodeAt(i)

--- a/packages/it-protobuf-stream/package.json
+++ b/packages/it-protobuf-stream/package.json
@@ -143,16 +143,16 @@
     "abort-error": "^1.0.2",
     "it-length-prefixed-stream": "^2.0.0",
     "it-stream-types": "^2.0.2",
-    "uint8arraylist": "^2.4.8"
+    "uint8arraylist": "^3.0.1"
   },
   "devDependencies": {
     "aegir": "^48.0.1",
     "it-map": "^3.0.0",
     "it-pair": "^2.0.6",
     "it-to-buffer": "^4.0.0",
-    "protons": "^8.1.1",
-    "protons-runtime": "^6.0.1",
-    "uint8-varint": "^2.0.4",
-    "uint8arrays": "^5.1.0"
+    "protons": "^9.0.0",
+    "protons-runtime": "^7.0.0",
+    "uint8-varint": "^3.0.0",
+    "uint8arrays": "^6.1.0"
   }
 }

--- a/packages/it-protobuf-stream/src/index.ts
+++ b/packages/it-protobuf-stream/src/index.ts
@@ -42,7 +42,7 @@ export interface Decoder<T> {
  * A protobuf encoder - takes an object and returns a byte array
  */
 export interface Encoder<T> {
-  (data: T): Uint8Array
+  (data: T): Uint8Array<ArrayBuffer>
 }
 
 /**

--- a/packages/it-protobuf-stream/test/fixtures/test-message.ts
+++ b/packages/it-protobuf-stream/test/fixtures/test-message.ts
@@ -78,7 +78,7 @@ export namespace TestMessage {
     value: string
   }
 
-  export function encode (obj: Partial<TestMessage>): Uint8Array {
+  export function encode (obj: Partial<TestMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, TestMessage.codec())
   }
 

--- a/packages/it-rpc/package.json
+++ b/packages/it-rpc/package.json
@@ -144,22 +144,22 @@
     "abort-error": "^1.0.2",
     "any-signal": "^4.2.0",
     "cborg": "^5.1.0",
-    "it-length-prefixed": "^10.0.1",
+    "it-length-prefixed": "^11.0.1",
     "it-pushable": "^3.2.3",
     "it-stream-types": "^2.0.2",
     "nanoid": "^5.1.7",
     "p-defer": "^4.0.1",
-    "protons-runtime": "^6.0.1",
+    "protons-runtime": "^7.0.0",
     "race-signal": "^2.0.0",
-    "uint8arraylist": "^2.4.8",
-    "uint8arrays": "^5.1.0"
+    "uint8arraylist": "^3.0.1",
+    "uint8arrays": "^6.1.0"
   },
   "devDependencies": {
     "aegir": "^48.0.1",
     "delay": "^7.0.0",
     "it-all": "^3.0.0",
     "it-drain": "^3.0.0",
-    "protons": "^8.1.1",
+    "protons": "^9.0.0",
     "sinon-ts": "^2.0.0"
   },
   "sideEffects": false

--- a/packages/it-rpc/src/index.ts
+++ b/packages/it-rpc/src/index.ts
@@ -335,7 +335,7 @@ export interface RPCInit {
   lpDecoder?: DecoderOptions
 }
 
-export interface RPC extends Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
+export interface RPC extends Duplex<AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>, AsyncGenerator<Uint8Array, void, unknown>> {
   createClient<T extends object> (name: string, options?: ClientOptions): T
   createTarget (name: string, target: any): void
 }
@@ -360,9 +360,9 @@ function isInvocationMessage (subMessage: any): boolean {
   return subMessage.type === MessageType.invokeMethod || subMessage.type === MessageType.invokeGeneratorMethod || subMessage.type === MessageType.invokeCallback
 }
 
-class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
-  public source: AsyncGenerator<Uint8Array, void, undefined>
-  private readonly output: Pushable<Uint8Array>
+class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>, AsyncGenerator<Uint8Array, void, unknown>> {
+  public source: AsyncGenerator<Uint8Array<ArrayBuffer>, void, undefined>
+  private readonly output: Pushable<Uint8Array<ArrayBuffer>>
 
   // used by the server end to track RPC invocation destinations
   private readonly targets: Map<string, any>
@@ -383,7 +383,7 @@ class DuplexRPC implements Duplex<AsyncGenerator<Uint8Array, void, unknown>> {
   private readonly lpDecoderOptions?: DecoderOptions
 
   constructor (init?: RPCInit) {
-    this.output = pushable()
+    this.output = pushable<Uint8Array<ArrayBuffer>>()
     this.source = lpEncode(this.output, init?.lpEncoder)
     this.lpDecoderOptions = init?.lpDecoder
 

--- a/packages/it-rpc/src/rpc.ts
+++ b/packages/it-rpc/src/rpc.ts
@@ -131,7 +131,7 @@ export namespace Value {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<Value>): Uint8Array {
+  export function encode (obj: Partial<Value>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, Value.codec())
   }
 
@@ -243,7 +243,7 @@ export namespace RPCMessage {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<RPCMessage>): Uint8Array {
+  export function encode (obj: Partial<RPCMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, RPCMessage.codec())
   }
 
@@ -408,7 +408,7 @@ export namespace InvokeMethodMessage {
     index: number
   }
 
-  export function encode (obj: Partial<InvokeMethodMessage>): Uint8Array {
+  export function encode (obj: Partial<InvokeMethodMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, InvokeMethodMessage.codec())
   }
 
@@ -497,7 +497,7 @@ export namespace AbortMethodMessage {
     value: string
   }
 
-  export function encode (obj: Partial<AbortMethodMessage>): Uint8Array {
+  export function encode (obj: Partial<AbortMethodMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, AbortMethodMessage.codec())
   }
 
@@ -615,7 +615,7 @@ export namespace MethodResolvedMessage {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<MethodResolvedMessage>): Uint8Array {
+  export function encode (obj: Partial<MethodResolvedMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MethodResolvedMessage.codec())
   }
 
@@ -733,7 +733,7 @@ export namespace MethodRejectedMessage {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<MethodRejectedMessage>): Uint8Array {
+  export function encode (obj: Partial<MethodRejectedMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, MethodRejectedMessage.codec())
   }
 
@@ -937,7 +937,7 @@ export namespace InvokeCallbackMessage {
     index: number
   }
 
-  export function encode (obj: Partial<InvokeCallbackMessage>): Uint8Array {
+  export function encode (obj: Partial<InvokeCallbackMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, InvokeCallbackMessage.codec())
   }
 
@@ -1068,7 +1068,7 @@ export namespace AbortCallbackMessage {
     value: string
   }
 
-  export function encode (obj: Partial<AbortCallbackMessage>): Uint8Array {
+  export function encode (obj: Partial<AbortCallbackMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, AbortCallbackMessage.codec())
   }
 
@@ -1228,7 +1228,7 @@ export namespace CallbackResolvedMessage {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<CallbackResolvedMessage>): Uint8Array {
+  export function encode (obj: Partial<CallbackResolvedMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, CallbackResolvedMessage.codec())
   }
 
@@ -1388,7 +1388,7 @@ export namespace CallbackRejectedMessage {
     value: Uint8Array
   }
 
-  export function encode (obj: Partial<CallbackRejectedMessage>): Uint8Array {
+  export function encode (obj: Partial<CallbackRejectedMessage>): Uint8Array<ArrayBuffer> {
     return encodeMessage(obj, CallbackRejectedMessage.codec())
   }
 

--- a/packages/it-split/package.json
+++ b/packages/it-split/package.json
@@ -138,12 +138,12 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "uint8arraylist": "^2.4.8"
+    "uint8arraylist": "^3.0.1"
   },
   "devDependencies": {
     "aegir": "^48.0.1",
     "buffer": "^6.0.3",
     "it-all": "^3.0.0",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^6.1.0"
   }
 }

--- a/packages/it-split/src/index.ts
+++ b/packages/it-split/src/index.ts
@@ -71,9 +71,9 @@ function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
 /**
  * Splits Uint8Arrays emitted by an (async) iterable by a delimiter
  */
-function split (source: Iterable<Uint8Array>, options?: SplitOptions): Generator<Uint8Array, void, undefined>
-function split (source: Iterable<Uint8Array> | AsyncIterable<Uint8Array>, options?: SplitOptions): AsyncGenerator<Uint8Array, void, undefined>
-function split (source: Iterable<Uint8Array> | AsyncIterable<Uint8Array>, options: SplitOptions = {}): AsyncGenerator<Uint8Array, void, undefined> | Generator<Uint8Array, void, undefined> {
+function split (source: Iterable<Uint8Array>, options?: SplitOptions): Generator<Uint8Array<ArrayBuffer>, void, undefined>
+function split (source: Iterable<Uint8Array> | AsyncIterable<Uint8Array>, options?: SplitOptions): AsyncGenerator<Uint8Array<ArrayBuffer>, void, undefined>
+function split (source: Iterable<Uint8Array> | AsyncIterable<Uint8Array>, options: SplitOptions = {}): AsyncGenerator<Uint8Array<ArrayBuffer>, void, undefined> | Generator<Uint8Array<ArrayBuffer>, void, undefined> {
   const bl = new Uint8ArrayList()
   const delimiter = options.delimiter ?? new TextEncoder().encode('\n')
 
@@ -108,7 +108,7 @@ function split (source: Iterable<Uint8Array> | AsyncIterable<Uint8Array>, option
   })()
 }
 
-function * yieldUntilEnd (bl: Uint8ArrayList, delimiter: Uint8Array): Generator<Uint8Array, void, undefined> {
+function * yieldUntilEnd (bl: Uint8ArrayList, delimiter: Uint8Array): Generator<Uint8Array<ArrayBuffer>, void, undefined> {
   let index = bl.indexOf(delimiter)
 
   while (index !== -1) {

--- a/packages/it-to-buffer/package.json
+++ b/packages/it-to-buffer/package.json
@@ -138,7 +138,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^6.1.0"
   },
   "devDependencies": {
     "aegir": "^48.0.1"

--- a/packages/it-to-buffer/src/index.ts
+++ b/packages/it-to-buffer/src/index.ts
@@ -42,13 +42,12 @@ function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
  * Takes an (async) iterable that yields buffer-like-objects and concats them
  * into one buffer
  */
-function toBuffer (source: Iterable<Uint8Array>): Uint8Array
-function toBuffer (source: Iterable<Uint8Array> | AsyncIterable<Uint8Array>): Promise<Uint8Array>
-function toBuffer (source: Iterable<Uint8Array> | AsyncIterable<Uint8Array>): Promise<Uint8Array> | Uint8Array {
+function toBuffer (source: Iterable<Uint8Array>): Uint8Array<ArrayBuffer>
+function toBuffer (source: Iterable<Uint8Array> | AsyncIterable<Uint8Array>): Promise<Uint8Array<ArrayBuffer>>
+function toBuffer (source: Iterable<Uint8Array> | AsyncIterable<Uint8Array>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer> {
   if (isAsyncIterable(source)) {
     return (async () => {
-      // https://github.com/microsoft/TypeScript/issues/61793
-      let buffer: Uint8Array = new Uint8Array(0)
+      let buffer = new Uint8Array(0)
 
       for await (const buf of source) {
         buffer = uint8ArrayConcat([buffer, buf], buffer.length + buf.length)


### PR DESCRIPTION
Since microsoft/TypeScript#59417 `Uint8Array`s backed by `ArrayBuffer` are incompatible with those backed with `SharedArrayBuffer` so be explicit about the types returned.

BREAKING CHANGE: returned `Uint8Array`s and `Uint8ArrayList`s now have a generic type that reflects the internal buffer type