### PR TITLE
fix: clean up source on a short read in it-parallel

### DIFF
--- a/packages/it-parallel/src/index.ts
+++ b/packages/it-parallel/src/index.ts
@@ -110,6 +110,7 @@ export default async function * parallel <T> (source: Iterable<() => Promise<T>>
   let sourceFinished = false
   let sourceErr: Error | undefined
   let opErred = false
+  let returned = false
 
   emitter.addEventListener('task-complete', () => {
     resultAvailable.resolve()
@@ -123,7 +124,7 @@ export default async function * parallel <T> (source: Iterable<() => Promise<T>>
           await slotAvailable.promise
         }
 
-        if (opErred) {
+        if (opErred || returned) {
           break
         }
 
@@ -205,34 +206,42 @@ export default async function * parallel <T> (source: Iterable<() => Promise<T>>
     }
   }
 
-  while (true) {
-    if (!valuesAvailable()) {
-      resultAvailable = defer()
-      await resultAvailable.promise
-    }
+  try {
+    while (true) {
+      if (!valuesAvailable()) {
+        resultAvailable = defer()
+        await resultAvailable.promise
+      }
 
-    if (sourceErr != null) {
-      // the source threw an error, propagate it
-      throw sourceErr
-    }
+      if (sourceErr != null) {
+        // the source threw an error, propagate it
+        throw sourceErr
+      }
 
-    if (ordered) {
-      yield * yieldOrderedValues()
-    } else {
-      yield * yieldUnOrderedValues()
-    }
+      if (ordered) {
+        yield * yieldOrderedValues()
+      } else {
+        yield * yieldUnOrderedValues()
+      }
 
-    if (sourceErr != null) {
-      // if the source yields an array that is `yield *`, it can throw while the
-      // onward consumer is processing the array contents - make sure we
-      // propagate the error
-      // eslint-disable-next-line @typescript-eslint/only-throw-error
-      throw sourceErr
-    }
+      if (sourceErr != null) {
+        // if the source yields an array that is `yield *`, it can throw while the
+        // onward consumer is processing the array contents - make sure we
+        // propagate the error
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw sourceErr
+      }
 
-    if (sourceFinished && ops.length === 0) {
-      // not waiting for any results and no more tasks so we are done
-      break
+      if (sourceFinished && ops.length === 0) {
+        // not waiting for any results and no more tasks so we are done
+        break
+      }
     }
+  } finally {
+    // the consumer has stopped iterating before the source was exhausted -
+    // let the source reader exit so the source iterator is returned and any
+    // resources it holds are freed
+    returned = true
+    slotAvailable.resolve()
   }
 }

--- a/packages/it-parallel/test/index.spec.ts
+++ b/packages/it-parallel/test/index.spec.ts
@@ -322,6 +322,6 @@ describe('it-parallel', () => {
     await delay(500)
 
     expect(received).to.have.lengthOf(2)
-    expect(sourceReturned).to.be.true()
+    expect(sourceReturned).to.be.true('source did not return')
   })
 })

--- a/packages/it-parallel/test/index.spec.ts
+++ b/packages/it-parallel/test/index.spec.ts
@@ -294,4 +294,34 @@ describe('it-parallel', () => {
     await expect(all(gen())).to.eventually.be.rejected
       .with.property('message', 'input threw')
   })
+
+  it('should stop reading the source on a short read', async () => {
+    let sourceReturned = false
+    const received: number[] = []
+
+    const source = async function * (): AsyncGenerator<() => Promise<number>, void, undefined> {
+      try {
+        for (let i = 0; i < 100; i++) {
+          const value = i
+          yield async () => value
+          await delay(10)
+        }
+      } finally {
+        sourceReturned = true
+      }
+    }
+
+    for await (const value of parallel(source(), { concurrency: 2 })) {
+      received.push(value)
+
+      if (received.length === 2) {
+        break
+      }
+    }
+
+    await delay(500)
+
+    expect(received).to.have.lengthOf(2)
+    expect(sourceReturned).to.be.true()
+  })
 })


### PR DESCRIPTION
When a consumer stops iterating `parallel()` early (for example by `break`ing out of a `for await` loop), the background task that reads from the source keeps running. It pulls a few more items to fill the concurrency slots, then blocks forever on a slot that never frees up. The source iterator's `return()` is never called, so a generator source never runs its `finally` block and any resources it holds stay open.

`it-merge` already handles this. #161 made it abort the queue push on a short read so the sources get cleaned up, and there is a test for it ("should abort queue push on a short read"). `it-parallel` has the same background-reader structure but never got the equivalent cleanup.

This adds a `returned` flag that the generator sets in a `finally` block once iteration stops. The source reader checks it next to the existing `opErred` flag and breaks out of its loop, which lets the `for await` call `return()` on the source.

Before the change, this leaves the source suspended:

```js
let cleanedUp = false
const source = async function * () {
  try {
    let i = 0
    while (true) {
      const value = i++
      yield async () => value
      await delay(10)
    }
  } finally {
    cleanedUp = true
  }
}

for await (const value of parallel(source(), { concurrency: 2 })) {
  break
}

await delay(100)
console.log(cleanedUp) // false before this change, true after
```

I added a test that mirrors the it-merge short-read test. It fails without the source change (the source's `finally` never runs) and passes with it. The existing tests still pass.
