### PR TITLE
fix(it-merge): return the source iterators when the consumer exits early

### DIFF
--- a/packages/it-merge/src/index.ts
+++ b/packages/it-merge/src/index.ts
@@ -47,12 +47,18 @@ function isAsyncIterable <T> (thing: any): thing is AsyncIterable<T> {
   return thing[Symbol.asyncIterator] != null
 }
 
-async function addAllToPushable <T> (sources: Array<AsyncIterable<T> | Iterable<T>>, output: Pushable<T>, signal: AbortSignal): Promise<void> {
+async function addAllToPushable <T> (iterators: Array<AsyncIterator<T> | Iterator<T>>, output: Pushable<T>, signal: AbortSignal): Promise<void> {
   try {
     await Promise.all(
-      sources.map(async (source) => {
-        for await (const item of source) {
-          await output.push(item, {
+      iterators.map(async (iterator) => {
+        while (true) {
+          const { value, done } = await iterator.next()
+
+          if (done === true) {
+            break
+          }
+
+          await output.push(value, {
             signal
           })
           signal.throwIfAborted()
@@ -75,13 +81,31 @@ async function * mergeSources <T> (sources: Array<AsyncIterable<T> | Iterable<T>
   const controller = new AbortController()
   const output = queuelessPushable<T>()
 
-  addAllToPushable(sources, output, controller.signal)
+  const iterators = sources.map(source => isAsyncIterable<T>(source)
+    ? source[Symbol.asyncIterator]()
+    : source[Symbol.iterator]())
+
+  addAllToPushable(iterators, output, controller.signal)
     .catch(() => {})
 
   try {
     yield * output
   } finally {
     controller.abort()
+
+    // Aborting only unblocks sources that are waiting to push. A source suspended at a yield
+    // is never signalled by it, so it would be left un-unwound forever along with everything
+    // its scope captured - return each iterator explicitly instead.
+    //
+    // Deliberately not awaited: a source parked mid-await leaves return() pending
+    // indefinitely, and awaiting it here would hang the consumer's `break`.
+    for (const iterator of iterators) {
+      try {
+        Promise.resolve(iterator.return?.()).catch(() => {})
+      } catch {
+        // an iterator that throws on return() has nothing further we can do for it
+      }
+    }
   }
 }
 

--- a/packages/it-merge/test/index.spec.ts
+++ b/packages/it-merge/test/index.spec.ts
@@ -150,4 +150,63 @@ describe('it-merge', () => {
     expect(values1Finally).to.be.true()
     expect(values2Finally).to.be.true()
   })
+
+  it('should clean up every source when the consumer breaks early', async () => {
+    // With more sources than the consumer reads, some are left suspended at a `yield` when the
+    // consumer breaks. Aborting the internal controller only unblocks sources that are waiting
+    // to push, so those suspended sources were never unwound and their `finally` never ran -
+    // leaking whatever their scope captured. Six sources makes the case reproducible; with two
+    // the timing happens to work out.
+    const cleanedUp = new Set<string>()
+
+    const source = (name: string): AsyncGenerator<string, void, undefined> => {
+      return (async function * () {
+        try {
+          for (let i = 0; i < 1000; i++) {
+            yield `${name}:${i}`
+          }
+        } finally {
+          cleanedUp.add(name)
+        }
+      })()
+    }
+
+    const names = ['a', 'b', 'c', 'd', 'e', 'f']
+    const sources = names.map(source)
+
+    let received = 0
+
+    for await (const value of merge(...sources)) {
+      received++
+
+      if (received === 3) {
+        expect(value).to.be.a('string')
+        break
+      }
+    }
+
+    await delay(100)
+
+    expect([...cleanedUp].sort()).to.deep.equal(names)
+  })
+
+  it('should not block the consumer on a source that cannot be unwound', async () => {
+    // A source parked mid-await cannot be unwound by `.return()` - the return request queues
+    // behind the pending await. Cleaning up must therefore not await the returns, or breaking
+    // out of the loop would hang forever.
+    const stuck = (async function * (): AsyncGenerator<number, void, undefined> {
+      yield 1
+      await new Promise(() => {})
+    })()
+
+    const start = Date.now()
+
+    for await (const value of merge(stuck)) {
+      if (value === 1) {
+        break
+      }
+    }
+
+    expect(Date.now() - start).to.be.lessThan(1000)
+  })
 })


### PR DESCRIPTION
When the consumer stops reading early, `mergeSources` only calls `controller.abort()`:

```js
async function * mergeSources (sources) {
  const controller = new AbortController()
  const output = queuelessPushable()
  addAllToPushable(sources, output, controller.signal).catch(() => {})
  try {
    yield * output
  } finally {
    controller.abort()      // unblocks sources waiting to push - and nothing else
  }
}
```

That unblocks sources currently waiting on `output.push()`. A source **suspended at a `yield`** is never signalled and never returned, so its `finally` never runs and everything its scope captured stays alive.

### Reproduction

Six sources, consumer breaks after three records:

```js
const cleanedUp = new Set()
const source = (name) => (async function * () {
  try { for (let i = 0; i < 1000; i++) yield `${name}:${i}` }
  finally { cleanedUp.add(name) }
})()

let received = 0
for await (const _ of merge(...["a","b","c","d","e","f"].map(source))) {
  if (++received === 3) break
}
// cleanedUp.size === 3   (expected 6)
```

**3 of 6 `finally` blocks never run**, and that holds when cleanup is polled out to 5 seconds, so it is not a timing artefact. The existing `should abort queue push on a short read` test uses two sources, where the timing happens to work out — which is why this went unnoticed.

### The fix

Take the iterators up front and return them explicitly on the way out.

The returns are **deliberately not awaited**. An async generator parked mid-`await` cannot be unwound at all — the return request queues behind the pending await — so awaiting here would hang the consumer's `break` forever. Two shapes, only one recoverable:

| source parked… | `.return()` unwinds it? |
|---|---|
| at a `yield` | **yes** — what this PR fixes |
| mid-`await`, nothing settles it | no — the caller must make that await abortable |

### Tests

Two added:
- `should clean up every source when the consumer breaks early` — the six-source case above. Fails on `main`, passes with the fix.
- `should not block the consumer on a source that cannot be unwound` — pins that the non-awaited returns cannot reintroduce a hang.

All four pre-existing tests still pass, including `should abort queue push on a short read`. `aegir lint` is clean.

### Why I went looking

Unbounded memory growth in a long-lived browser tab built on libp2p/helia.
`CompoundContentRouting.findProviders` merges one source per HTTP router with `it-merge`, and
the caller breaks out as soon as it has enough peers — stranding the other routers' generators
at a `yield`. Each holds an `any-signal` abort listener whose `signal.clear()` lives in the
`finally` that never runs.

Two headless browsers on the same machine, same live peers, launched together, differing by
**exactly this patch**:

| after cold start | without this patch | with it |
|---|---:|---:|
| RSS slope | **+2,823 MB/h** | **−90 MB/h** |
| outcome | hit a 6 GB ceiling and was killed at 2h19m | **still 1,117 MB at 2h22m** |

An earlier run reproduces the unpatched side: 6,383 MB in ~2.2 h. Elapsed time here is
*runtime*, not wall clock — an earlier attempt was invalidated by the machine suspending
overnight.

I want to be explicit that this is ~2.4 h of observation, not a multi-day soak, and that RSS in
this system is a sawtooth. What I think it does support is the *divergence*: one arm 6× the
other and climbing, on the same workload, with a mechanism that is independently demonstrated
by the repro above.

One correction worth stating plainly, since I filed a related issue elsewhere on the strength
of it: I originally justified this by counting objects "retained" in a Firefox GC heap dump. In
Gecko a listener-bearing `EventTarget` **is** collected — the cycle collector reclaims it — so
reachability in a `gc-edges` dump does not imply retention. I've retracted the claims that
rested on that (ipfs/helia#1101). The evidence above is RSS and the standalone repro, neither
of which depends on that inference.
